### PR TITLE
Bugfix/8 base with children bug

### DIFF
--- a/src/lib/decorators/afterAndBefore.decorator.ts
+++ b/src/lib/decorators/afterAndBefore.decorator.ts
@@ -38,6 +38,12 @@ export function beforeEach() {
 
 
 function getTestSuiteInstance(target: any) {
-    if (!target.__testSuiteInstance) { target.__testSuiteInstance = new TestSuite(); }
+    if (!target.__testSuiteInstance) {
+        target.__testSuiteInstance = new TestSuite();
+    }
+    else {
+        target.__testSuiteInstance = (target.__testSuiteInstance as TestSuite).clone();
+    }
+
     return target.__testSuiteInstance;
 }

--- a/src/lib/decorators/test.decorator.ts
+++ b/src/lib/decorators/test.decorator.ts
@@ -39,7 +39,12 @@ export function xtest(name?: string, testCases?: TestCase[], timeout: number = 2
 }
 
 function initializeTarget(target: any) {
-    if (!target.__testSuiteInstance) { target.__testSuiteInstance = new TestSuite(); }
+    if (!target.__testSuiteInstance) {
+        target.__testSuiteInstance = new TestSuite();
+    }
+    else {
+        target.__testSuiteInstance = (target.__testSuiteInstance as TestSuite).clone();
+    }
 }
 
 function generateDecoratorFunction(name: string, status: TestStatus, testCases: TestCase[], timeout: number) {

--- a/src/lib/tests/test.ts
+++ b/src/lib/tests/test.ts
@@ -18,4 +18,8 @@ export class Test {
     public async accept<T>(visitor: TestVisitor<T>): Promise<T> {
         return await visitor.visitTest(this);
     }
+
+    public clone() {
+        return new Test(this.name, this._func, this._status);
+    }
 }

--- a/src/lib/tests/testSuite.ts
+++ b/src/lib/tests/testSuite.ts
@@ -69,9 +69,7 @@ export class TestSuite extends Map<string, Test | TestSuite> {
     private getNormalizedCopy(): Test | TestSuite {
         if (this.status === TestStatus.Focused) { return this; }
 
-        const copy = new TestSuite();
-        copy.name = this.name;
-        copy.context = this.context;
+        const copy = this.clone();
         for (const id of this.testIds) {
             const testOrTestSuite = super.get(id);
             if (testOrTestSuite instanceof Map) {
@@ -80,6 +78,23 @@ export class TestSuite extends Map<string, Test | TestSuite> {
             else {
                 copy.set(id, new Test(testOrTestSuite.name, testOrTestSuite.func, testOrTestSuite.status === TestStatus.Focused ? TestStatus.Focused : TestStatus.Ignored));
             }
+        }
+
+        return copy;
+    }
+
+    public clone(): TestSuite {
+        const copy = new TestSuite();
+        copy.name = this.name;
+        copy.status = this.status;
+        copy.context = this.context;
+        copy.afterAllMethods = this.afterAllMethods.slice();
+        copy.afterEachMethods = this.afterEachMethods.slice();
+        copy.beforeEachMethods = this.beforeEachMethods.slice();
+        copy.beforeAllMethods = this.beforeAllMethods.slice();
+
+        for (const key of this.testIds) {
+            copy.set(key, super.get(key).clone());
         }
 
         return copy;

--- a/src/spec/decorators/baseTestSuite/baseWithChildren.ts
+++ b/src/spec/decorators/baseTestSuite/baseWithChildren.ts
@@ -1,0 +1,16 @@
+import { testSuite, test } from '../../../testyCore';
+import { beforeEach } from '../../../lib/decorators/afterAndBefore.decorator';
+
+class Base {
+    @beforeEach() beforeEach() { }
+}
+
+@testSuite()
+export class TestSuiteA extends Base {
+    @test() testA() { }
+}
+
+@testSuite()
+export class TestSuiteB extends Base {
+    @test() testB() { }
+}

--- a/src/spec/decorators/baseTestSuite/testSuiteWithBase.ts
+++ b/src/spec/decorators/baseTestSuite/testSuiteWithBase.ts
@@ -1,7 +1,6 @@
 import { test, beforeAll, beforeEach, afterEach, afterAll } from '../../../testyCore';
 import { testSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Base Test Suite')
 export class BaseTestSuite {
     public beforeAllExecuted = [];
     public beforeEachExecuted = [];
@@ -29,6 +28,7 @@ export class BaseTestSuite {
     }
 }
 
+@testSuite('Test Suite')
 export class TestSuiteWithBase extends BaseTestSuite {
     @beforeAll()
     private beforeAll() {

--- a/src/spec/decorators/baseTestSuite/testWithBase.spec.ts
+++ b/src/spec/decorators/baseTestSuite/testWithBase.spec.ts
@@ -1,6 +1,7 @@
-import { testSuite, test, expect } from '../../../testyCore';
+import { testSuite, test, expect, ftest } from '../../../testyCore';
 import { TestSuiteTestsBase } from '../testSuiteTestsBase';
 import { TestSuiteWithBase, BaseTestSuite } from './testSuiteWithBase';
+import { TestSuiteA, TestSuiteB } from './baseWithChildren';
 
 @testSuite('Test Suite With Base Test Suite Tests')
 export class BeforeAfterDecoratorsTestSuite extends TestSuiteTestsBase {
@@ -22,6 +23,17 @@ export class BeforeAfterDecoratorsTestSuite extends TestSuiteTestsBase {
         expect.toBeEqual(testSuite.context.afterEachExecuted[1], TestSuiteWithBase);
         expect.toBeEqual(testSuite.context.afterAllExecuted[0], BaseTestSuite);
         expect.toBeEqual(testSuite.context.afterAllExecuted[1], TestSuiteWithBase);
+    }
+
+    @test('base with multiple children')
+    private async baseWithMultipleChildren() {
+        // Arrange
+        const a = this.getTestSuiteInstance(TestSuiteA);
+        const b = this.getTestSuiteInstance(TestSuiteB);
+
+        // Assert
+        expect.arraysToBeEqual(a.testIds, ['testA']);
+        expect.arraysToBeEqual(b.testIds, ['testB']);
     }
 }
 

--- a/src/spec/tests/testSuite.spec.ts
+++ b/src/spec/tests/testSuite.spec.ts
@@ -1,4 +1,4 @@
-import { testSuite, test, expect } from '../../testyCore';
+import { testSuite, test, expect, ftest } from '../../testyCore';
 import { TestSuite } from '../../lib/tests/testSuite';
 import { TestStatus } from '../../lib/testStatus';
 import { Test } from '../../lib/tests/test';
@@ -159,5 +159,31 @@ export class TestSuiteTests {
         expect.toBeEqual((actualTestcases.get('a.c') as Test).status, TestStatus.Normal);
         expect.toBeEqual((testsuite.get('b') as Test).status, TestStatus.Ignored);
         expect.toBeEqual((testsuite.get('c') as Test).status, TestStatus.Normal);
+    }
+
+    @test('clone')
+    clone() {
+        // Arrange
+        const testcases = new TestSuite();
+        testcases.context = { key: 'somedummycontext' };
+        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Ignored));
+        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+
+        const testsuite = new TestSuite();
+        testsuite.set('a', testcases);
+        testsuite.set('b', new Test('b', undefined, TestStatus.Ignored));
+        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+
+        // Act
+        const clone = testcases.clone();
+
+        // Assert
+        expect.not.toBeEqual(clone, testsuite);
+        expect.arraysToBeEqual(clone.testIds, testcases.testIds);
+        expect.arraysToBeEqual(clone.beforeAllMethods, testsuite.beforeAllMethods);
+        expect.arraysToBeEqual(clone.beforeEachMethods, testsuite.beforeEachMethods);
+        expect.arraysToBeEqual(clone.afterEachMethods, testsuite.afterEachMethods);
+        expect.arraysToBeEqual(clone.afterEachMethods, testsuite.afterAllMethods);
     }
 }


### PR DESCRIPTION
## Purpose
Fix #8 .

## Approach
Made the decorators use a copy of the __testSuiteInstance instead of the reference. This way, when the children decorators are called, they use their own copy instead of sharing the base 

## Learnings
https://stackoverflow.com/questions/48122319/why-do-typescript-decorators-on-a-base-class-cause-extensions-to-affect-one-anot
