### PR TITLE
Feature/16 test report summary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+### 0.5.2
+  - Added test report summary
+
 ### 0.5.1
  - Refactored a few methods to improve the maintainability
  - Fixed the base class bug

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "testyts",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "icon": "img/test-icon-128x128.png",
     "description": "Modern test framework for TypeScript.",
     "main": "build/testyCore.js",

--- a/src/lib/cli/run.command.ts
+++ b/src/lib/cli/run.command.ts
@@ -39,7 +39,7 @@ export class RunCommand implements CliCommand {
     private async loadConfig<T>(file: string): Promise<T> {
         const path = resolve(process.cwd(), file);
         if (!existsSync(path))
-            throw new Error(`;The; specified; configuration; file; could; not; be; found: $; {path; }`);
+            throw new Error(`The specified configuration file could not be found: ${path}`);
 
         return await import(path);
     }

--- a/src/lib/tests/rootTestSuite.ts
+++ b/src/lib/tests/rootTestSuite.ts
@@ -1,0 +1,9 @@
+import { TestSuite } from './testSuite';
+
+export class RootTestSuite extends TestSuite {
+
+    constructor() {
+        super();
+        this.name = 'Root';
+    }
+}

--- a/src/lib/tests/rootTestSuite.ts
+++ b/src/lib/tests/rootTestSuite.ts
@@ -1,9 +1,14 @@
 import { TestSuite } from './testSuite';
+import { TestVisitor } from './visitors/testVisitor';
 
 export class RootTestSuite extends TestSuite {
 
     constructor() {
         super();
         this.name = 'Root';
+    }
+
+    public accept<T>(visitor: TestVisitor<T>) {
+        return visitor.visitRootTestSuite(this);
     }
 }

--- a/src/lib/tests/testSuite.ts
+++ b/src/lib/tests/testSuite.ts
@@ -6,6 +6,7 @@ import { TestVisitor } from './visitors/testVisitor';
  * Contains a collection of tests and of test suites.
  */
 export class TestSuite extends Map<string, Test | TestSuite> {
+
     public name: string;
     public status: TestStatus;
     public context: any;

--- a/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
+++ b/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
@@ -1,11 +1,13 @@
-import { TestVisitor } from '../testVisitor';
-import { Test } from '../../test';
-import { TestSuite } from '../../testSuite';
 import { Logger } from '../../../logger/logger';
+import { CompositeReport } from '../../../reporting/report/compositeReport';
+import { FailedTestReport } from '../../../reporting/report/failedTestReport';
 import { Report } from '../../../reporting/report/report';
 import { TestResult } from '../../../reporting/report/testResult';
-import { FailedTestReport } from '../../../reporting/report/failedTestReport';
+import { Test } from '../../test';
+import { TestSuite } from '../../testSuite';
+import { TestVisitor } from '../testVisitor';
 import { TestsVisitorDecorator } from './testsVisitorDecorator';
+import { RootTestSuite } from '../../rootTestSuite';
 
 export class LoggerTestReporterDecorator extends TestsVisitorDecorator<Report> {
 

--- a/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
+++ b/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
@@ -39,12 +39,16 @@ export class LoggerTestReporterDecorator extends TestsVisitorDecorator<Report> {
 
         this.logger.decreaseIndentation();
 
-        if (tests instanceof RootTestSuite) {
-            this.logger.info();
-            this.printSummary(returnValue as CompositeReport);
-        }
-
         return returnValue;
+    }
+
+    public async visitRootTestSuite(tests: RootTestSuite): Promise<CompositeReport> {
+        const report = await this.visitTestSuite(tests) as CompositeReport;
+
+        this.logger.info();
+        this.printSummary(report);
+
+        return report;
     }
 
     private printSummary(tests: CompositeReport) {

--- a/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
+++ b/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
@@ -37,6 +37,20 @@ export class LoggerTestReporterDecorator extends TestsVisitorDecorator<Report> {
 
         this.logger.decreaseIndentation();
 
+        if (tests instanceof RootTestSuite) {
+            this.logger.info();
+            this.printSummary(returnValue as CompositeReport);
+        }
+
         return returnValue;
+    }
+
+    private printSummary(tests: CompositeReport) {
+        const success = tests.numberOfSuccessfulTests;
+        const failed = tests.numberOfTests - tests.numberOfSuccessfulTests;
+        const skipped = tests.numberOfSkippedTests;
+        const total = tests.numberOfTests;
+
+        this.logger.info(`Summary: ${success}/${total} passed, ${failed}/${total} failed, ${skipped}/${total} skipped.`);
     }
 }

--- a/src/lib/tests/visitors/decorators/testsVisitorDecorator.ts
+++ b/src/lib/tests/visitors/decorators/testsVisitorDecorator.ts
@@ -1,6 +1,7 @@
 import { TestVisitor } from '../testVisitor';
 import { Test } from '../../test';
 import { TestSuite } from '../../testSuite';
+import { RootTestSuite } from '../../rootTestSuite';
 
 export abstract class TestsVisitorDecorator<T> implements TestVisitor<T> {
     protected baseVisitTest: (testSuite: Test) => Promise<T>;
@@ -16,4 +17,5 @@ export abstract class TestsVisitorDecorator<T> implements TestVisitor<T> {
 
     abstract visitTest(test: Test): Promise<T>;
     abstract visitTestSuite(test: TestSuite): Promise<T>;
+    abstract visitRootTestSuite(test: RootTestSuite): Promise<T>;
 }

--- a/src/lib/tests/visitors/failedTestsReportVisitor.ts
+++ b/src/lib/tests/visitors/failedTestsReportVisitor.ts
@@ -7,6 +7,7 @@ import { TestStatus } from '../../testStatus';
 import { SkippedTestReport } from '../../reporting/report/skippedTestReport';
 import { FailedTestReport } from '../../reporting/report/failedTestReport';
 import { LeafReport } from '../../reporting/report/leafReport';
+import { RootTestSuite } from '../rootTestSuite';
 
 export class FailedTestsReportVisitor implements TestVisitor<Report> {
     constructor(private reason: string) { }
@@ -27,5 +28,9 @@ export class FailedTestsReportVisitor implements TestVisitor<Report> {
         }
 
         return report;
+    }
+
+    public async visitRootTestSuite(tests: RootTestSuite): Promise<Report> {
+        return await this.visitTestSuite(tests);
     }
 }

--- a/src/lib/tests/visitors/testRunnerVisitor.ts
+++ b/src/lib/tests/visitors/testRunnerVisitor.ts
@@ -9,6 +9,7 @@ import { CompositeReport } from '../../reporting/report/compositeReport';
 import { FailedTestsReportVisitor } from './failedTestsReportVisitor';
 import { LeafReport } from '../../reporting/report/leafReport';
 import { TestVisitor } from './testVisitor';
+import { RootTestSuite } from '../rootTestSuite';
 
 export class TestRunnerVisitor implements TestVisitor<Report> {
     private testSuites: TestSuite[] = [];
@@ -64,6 +65,10 @@ export class TestRunnerVisitor implements TestVisitor<Report> {
             const testReport = await (test as Test).accept<Report>(this);
             report.addReport(testReport);
         }
+    }
+
+    public async visitRootTestSuite(tests: RootTestSuite): Promise<Report> {
+        return await this.visitTestSuite(tests);
     }
 
     private async runAll(methods, context: any) {

--- a/src/lib/tests/visitors/testVisitor.ts
+++ b/src/lib/tests/visitors/testVisitor.ts
@@ -1,7 +1,9 @@
 import { Test } from '../test';
 import { TestSuite } from '../testSuite';
+import { RootTestSuite } from '../rootTestSuite';
 
 export interface TestVisitor<T> {
     visitTest(test: Test): Promise<T>;
     visitTestSuite(testSuite: TestSuite): Promise<T>;
+    visitRootTestSuite(testSuite: RootTestSuite): Promise<T>;
 }

--- a/src/lib/utils/testsLoader.ts
+++ b/src/lib/utils/testsLoader.ts
@@ -1,19 +1,20 @@
-import * as path from 'path';
 import * as glob from 'glob';
-import { Logger } from '../logger/logger';
+import * as path from 'path';
 import * as tsnode from 'ts-node';
+import { Logger } from '../logger/logger';
+import { RootTestSuite } from '../tests/rootTestSuite';
 import { TestSuite } from '../tests/testSuite';
 
 export class TestsLoader {
+
     private static isTsnodeRegistered = false;
+
     constructor(private logger?: Logger) { }
 
     public async loadTests(root: string, patterns: string[], tsconfig: tsnode.Options): Promise<TestSuite> {
         this.registerTranspiler(tsconfig);
 
-        const testSuites = new TestSuite();
-        testSuites.name = 'Root';
-
+        const testSuites = new RootTestSuite();
         const files = await this.getTestFiles(root, patterns);
         for (const file of files) {
             const testInstances = await this.getTestInstancesFromFile(file);


### PR DESCRIPTION
## Purpose
Print a summary at the end of a test report.

## Approach
Implemented a `RootTestSuite` which extends the `TestSuite` class. The `LoggerTestReporterDecorator` checks if the current test suite is a `RootTestSuite`. If so, it prints the summary.

**Example**
![image](https://user-images.githubusercontent.com/6698529/50251199-1bae1900-03b1-11e9-96c2-09572746f269.png)



