### PR TITLE
Capitalized decorators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+### 0.7.0
+ - Renamed all decorators so they begin with capital letters, to match other big packages conventions
+
 ### 0.6.0
  - Is actually 0.5.1 republished under 0.6.0 because of some breaking changes.
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ $ testyts init
 Writing tests with Testy is simple. Don't forget to export your test suites though. Otherwise, they won't be discovered by the test runner.
 
 ```ts
-@testSuite()
+@TestSuite()
 export class MyTestSuite {
 
-    @test()
+    @Test()
     onePlusOne() {
         // Act
         const result = 1 + 1;
@@ -49,25 +49,25 @@ export class MyTestSuite {
 Testy provides setup and teardown hooks.
 
 ```ts
-@testSuite()
+@TestSuite()
 export class MyTestSuite {
 
-    @beforeAll()
+    @BeforeAll()
     beforeAll() {
         // This is executed before all the tests
     }
 
-    @beforeEach()
+    @BeforeEach()
     beforeEach() {
         // This is executed before each test
     }
 
-    @afterEach()
+    @AfterEach()
     afterEach() {
         // This is executed after each test
     }
     
-    @afterAll()
+    @AfterAll()
     afterAll() {
         // This is executed after all the tests
     }
@@ -83,7 +83,7 @@ class MyBaseTestSuite{
     // Setup/teardown extravaganza
 }
 
-@testSuite()
+@TestSuite()
 class MyTestSuite extends MyBaseTestSuite {
     // My tests
 }
@@ -92,9 +92,9 @@ class MyTestSuite extends MyBaseTestSuite {
 ### Test cases
 
 ```ts
-@testSuite()
+@TestSuite()
 export class MyTestSuite {
-    @test('Addition', [
+    @Test('Addition', [
           new TestCase('Two plus two is four', 2, 2, 4),
           new TestCase(`Minus one that's three`, 4, -1, 3)
     ])
@@ -122,14 +122,14 @@ expect.toBeSorted.inAscendingOrder([0, 1, 1, 2, 3, 5, 8]);
 You can ignore tests by adding an `x` before a test suite or a specific test decorator. Ignored tests will still show up in the test report, but they will be marked as ignored.
 
 ```ts
-@xtestSuite() // This test suite will be ignored
+@XTestSuite() // This test suite will be ignored
 export class MyTestSuite { 
 // Your tests
 }
 
-@testSuite()
+@TestSuite()
 export class MyTestSuite {
-    @xtest() // This test will be ignored
+    @XTest() // This test will be ignored
     onePlusOne() {
        // Some test
     }
@@ -139,14 +139,14 @@ export class MyTestSuite {
 You can also focus tests by adding an `f` before a test suite or a specific test decorator. If one test or test suites are focused, only those will be runned. The others will be reported as ignored.
 
 ```ts
-@ftestSuite() // This test suite will be focused.
+@FTestSuite() // This test suite will be focused.
 export class MyTestSuite { 
 ...
 }
 
-@testSuite()
+@TestSuite()
 export class MyTestSuite {
-    @ftest() // This test will be focused
+    @FTest() // This test will be focused
     onePlusOne() {
        // Your test
     }
@@ -158,10 +158,10 @@ export class MyTestSuite {
 The tests and test suites names are inferred from the method or class name by default. You can specify a custom name.
 
 ```ts
-@testSuite('My glorious test suite')
+@TestSuite('My glorious test suite')
 export class MyTestSuite {
 
-    @test('Adding one plus one, should equal two')
+    @Test('Adding one plus one, should equal two')
     onePlusOne() {
         // Act
         const result = 1 + 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "testyts",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "testyts",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "icon": "img/test-icon-128x128.png",
     "description": "Modern test framework for TypeScript.",
     "main": "build/testyCore.js",

--- a/src/lib/decorators/afterAndBefore.decorator.ts
+++ b/src/lib/decorators/afterAndBefore.decorator.ts
@@ -1,9 +1,9 @@
-import { TestSuite } from '../tests/testSuite';
+import { TestSuiteInstance } from '../tests/testSuite';
 
 /** 
  * Method which is executed after all the tests were ran. 
  */
-export function afterAll() {
+export function AfterAll() {
     return (target, key, descriptor) => {
         getTestSuiteInstance(target).afterAllMethods.push(descriptor.value);
     };
@@ -12,7 +12,7 @@ export function afterAll() {
 /** 
  * Method which is executed after each test is ran. 
  */
-export function afterEach() {
+export function AfterEach() {
     return (target, key, descriptor) => {
         getTestSuiteInstance(target).afterEachMethods.push(descriptor.value);
     };
@@ -21,7 +21,7 @@ export function afterEach() {
 /**
  * Method which is executed before all the tests are ran.
  */
-export function beforeAll() {
+export function BeforeAll() {
     return (target, key, descriptor) => {
         getTestSuiteInstance(target).beforeAllMethods.push(descriptor.value);
     };
@@ -30,19 +30,51 @@ export function beforeAll() {
 /** 
  * Method which is executed before each test is ran.
  */
-export function beforeEach() {
+export function BeforeEach() {
     return (target, key, descriptor) => {
         getTestSuiteInstance(target).beforeEachMethods.push(descriptor.value);
     };
 }
 
+/** 
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Method which is executed after all the tests were ran. 
+ */
+export function afterAll() {
+    return AfterAll();
+}
+
+/** 
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Method which is executed after each test is ran. 
+ */
+export function afterEach() {
+    return AfterEach();
+}
+
+/**
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Method which is executed before all the tests are ran.
+ */
+export function beforeAll() {
+    return BeforeAll();
+}
+
+/** 
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Method which is executed before each test is ran.
+ */
+export function beforeEach() {
+    return BeforeEach();
+}
+
 
 function getTestSuiteInstance(target: any) {
     if (!target.__testSuiteInstance) {
-        target.__testSuiteInstance = new TestSuite();
+        target.__testSuiteInstance = new TestSuiteInstance();
     }
     else {
-        target.__testSuiteInstance = (target.__testSuiteInstance as TestSuite).clone();
+        target.__testSuiteInstance = (target.__testSuiteInstance as TestSuiteInstance).clone();
     }
 
     return target.__testSuiteInstance;

--- a/src/lib/decorators/test.decorator.ts
+++ b/src/lib/decorators/test.decorator.ts
@@ -1,21 +1,58 @@
 import { TestCase } from '../testCase';
 import { TestStatus } from '../testStatus';
-import { Test } from '../tests/test';
-import { TestSuite } from '../tests/testSuite';
+import { TestInstance } from '../tests/test';
+import { TestSuiteInstance } from '../tests/testSuite';
 
 /**
- * Marks a method inside a @testSuite decorated class as a test.
+ * Marks a method inside a @TestSuite decorated class as a test.
+ *
+ * @param name Name of the test, displayed in the test report.
+ * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
+ * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
+ */
+export function Test(name?: string, testCases?: TestCase[], timeout: number = 2000) {
+    return generateDecoratorFunction(name, TestStatus.Normal, testCases, timeout);
+}
+
+/**
+ * Marks a method inside a @TestSuite decorated class as a focused test.
+ * If one or more tests are marked as focused, only those will be ran.
+ *
+ * @param name Name of the test, displayed in the test report.
+ * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
+ * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
+ */
+export function FTest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
+    return generateDecoratorFunction(name, TestStatus.Focused, testCases, timeout);
+}
+
+/** 
+ * Marks a method inside a @TestSuite decorated class as an ignored test.
+ * Ignored tests will not be ran, but they will still appear in test reports.
+ * 
+ * @param name Name of the test, displayed in the test report.
+ * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
+ * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
+ */
+export function XTest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
+    return generateDecoratorFunction(name, TestStatus.Ignored, testCases, timeout);
+}
+
+/**
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Marks a method inside a @TestSuite decorated class as a test.
  *
  * @param name Name of the test, displayed in the test report.
  * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
  * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
 export function test(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return generateDecoratorFunction(name, TestStatus.Normal, testCases, timeout);
+    return Test(name, testCases, timeout);
 }
 
 /**
- * Marks a method inside a @testSuite decorated class as a focused test.
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Marks a method inside a @TestSuite decorated class as a focused test.
  * If one or more tests are marked as focused, only those will be ran.
  *
  * @param name Name of the test, displayed in the test report.
@@ -23,11 +60,12 @@ export function test(name?: string, testCases?: TestCase[], timeout: number = 20
  * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
 export function ftest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return generateDecoratorFunction(name, TestStatus.Focused, testCases, timeout);
+    return FTest(name, testCases, timeout);
 }
 
 /** 
- * Marks a method inside a @testSuite decorated class as an ignored test.
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Marks a method inside a @TestSuite decorated class as an ignored test.
  * Ignored tests will not be ran, but they will still appear in test reports.
  * 
  * @param name Name of the test, displayed in the test report.
@@ -35,22 +73,22 @@ export function ftest(name?: string, testCases?: TestCase[], timeout: number = 2
  * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
 export function xtest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return generateDecoratorFunction(name, TestStatus.Ignored, testCases, timeout);
+    return XTest(name, testCases, timeout);
 }
 
 function initializeTarget(target: any) {
     if (!target.__testSuiteInstance) {
-        target.__testSuiteInstance = new TestSuite();
+        target.__testSuiteInstance = new TestSuiteInstance();
     }
     else {
-        target.__testSuiteInstance = (target.__testSuiteInstance as TestSuite).clone();
+        target.__testSuiteInstance = (target.__testSuiteInstance as TestSuiteInstance).clone();
     }
 }
 
 function generateDecoratorFunction(name: string, status: TestStatus, testCases: TestCase[], timeout: number) {
     return (target, key, descriptor) => {
         initializeTarget(target);
-        const testSuiteInstance: TestSuite = target.__testSuiteInstance;
+        const testSuiteInstance: TestSuiteInstance = target.__testSuiteInstance;
 
         name = name ? name : key;
         if (testSuiteInstance.has(name)) {
@@ -61,18 +99,18 @@ function generateDecoratorFunction(name: string, status: TestStatus, testCases: 
     };
 }
 
-function generateTest(name: string, testCases: TestCase[], status: TestStatus, testMethod: Function, timeout: number): Test | TestSuite {
+function generateTest(name: string, testCases: TestCase[], status: TestStatus, testMethod: Function, timeout: number): TestInstance | TestSuiteInstance {
     return testCases
         ? generateTestsFromTestcases(name, testMethod, testCases, status, timeout)
-        : new Test(name, decorateStandaloneTest(testMethod, timeout), status);
+        : new TestInstance(name, decorateStandaloneTest(testMethod, timeout), status);
 }
 
-function generateTestsFromTestcases(name: string, testMethod: Function, testCases: TestCase[], status: TestStatus, timeout: number): TestSuite {
-    const tests = new TestSuite();
+function generateTestsFromTestcases(name: string, testMethod: Function, testCases: TestCase[], status: TestStatus, timeout: number): TestSuiteInstance {
+    const tests = new TestSuiteInstance();
     tests.name = name;
     for (const testCase of testCases) {
         const decoratedTestMethod = decorateTestWithTestcase(testMethod, testCase, timeout);
-        tests.set(testCase.name, new Test(testCase.name, decoratedTestMethod, status));
+        tests.set(testCase.name, new TestInstance(testCase.name, decoratedTestMethod, status));
     }
 
     return tests;

--- a/src/lib/decorators/testSuite.decorator.ts
+++ b/src/lib/decorators/testSuite.decorator.ts
@@ -1,12 +1,12 @@
 import { TestStatus } from '../testStatus';
-import { TestSuite } from '../tests/testSuite';
+import { TestSuiteInstance } from '../tests/testSuite';
 
 /** 
  * Marks a class as a test suite. 
  * 
  * @param name Name of the test suite, displayed in the test report.
  */
-export function testSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
+export function TestSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
     return createTestSuiteDecoratorFactory<T>(TestStatus.Normal, name);
 }
 
@@ -15,7 +15,7 @@ export function testSuite<T extends { new(...args: any[]): {} }>(name?: string):
  * 
  * @param name Name of the test suite, displayed in the test report.
  */
-export function ftestSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
+export function FTestSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
     return createTestSuiteDecoratorFactory<T>(TestStatus.Focused, name);
 }
 
@@ -24,8 +24,38 @@ export function ftestSuite<T extends { new(...args: any[]): {} }>(name?: string)
  * 
  * @param name Name of the test suite, displayed in the test report.
  */
-export function xtestSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
+export function XTestSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
     return createTestSuiteDecoratorFactory<T>(TestStatus.Ignored, name);
+}
+
+/** 
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Marks a class as a test suite. 
+ * 
+ * @param name Name of the test suite, displayed in the test report.
+ */
+export function testSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
+    return TestSuite(name);
+}
+
+/** 
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Marks a class as a focused test suite. If one or more test suites are marked as focused, only the those will be ran.
+ * 
+ * @param name Name of the test suite, displayed in the test report.
+ */
+export function ftestSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
+    return FTestSuite(name);
+}
+
+/**
+ * @deprecated since 0.7.0. Prefer using the capitalized version.
+ * Marks a class as an ignored test suite. Its tests will not be ran, but will still show up in the test report.
+ * 
+ * @param name Name of the test suite, displayed in the test report.
+ */
+export function xtestSuite<T extends { new(...args: any[]): {} }>(name?: string): any {
+    return XTestSuite(name);
 }
 
 function createTestSuiteDecoratorFactory<T extends { new(...args: any[]): {} }>(status: TestStatus, name?: string) {
@@ -36,9 +66,9 @@ function createTestSuiteDecoratorFactory<T extends { new(...args: any[]): {} }>(
     };
 }
 
-function createTestSuite<T>(constructor: new () => T, name: string, status: TestStatus): TestSuite {
+function createTestSuite<T>(constructor: new () => T, name: string, status: TestStatus): TestSuiteInstance {
     const context = new constructor();
-    const testSuiteInstance: TestSuite = (context as any).__testSuiteInstance;
+    const testSuiteInstance: TestSuiteInstance = (context as any).__testSuiteInstance;
     testSuiteInstance.name = name;
     testSuiteInstance.status = status;
     testSuiteInstance.context = context;

--- a/src/lib/tests/rootTestSuite.ts
+++ b/src/lib/tests/rootTestSuite.ts
@@ -1,7 +1,7 @@
-import { TestSuite } from './testSuite';
+import { TestSuiteInstance } from './testSuite';
 import { TestVisitor } from './visitors/testVisitor';
 
-export class RootTestSuite extends TestSuite {
+export class RootTestSuite extends TestSuiteInstance {
 
     constructor() {
         super();

--- a/src/lib/tests/test.ts
+++ b/src/lib/tests/test.ts
@@ -1,7 +1,7 @@
 import { TestStatus } from '../testStatus';
 import { TestVisitor } from './visitors/testVisitor';
 
-export class Test {
+export class TestInstance {
     public get name() { return this._name; }
     public get status() { return this._status; }
     public get func() { return this._func; }
@@ -20,6 +20,6 @@ export class Test {
     }
 
     public clone() {
-        return new Test(this.name, this._func, this._status);
+        return new TestInstance(this.name, this._func, this._status);
     }
 }

--- a/src/lib/tests/testSuite.ts
+++ b/src/lib/tests/testSuite.ts
@@ -1,16 +1,16 @@
-import { Test } from './test';
+import { TestInstance } from './test';
 import { TestStatus } from '../testStatus';
 import { TestVisitor } from './visitors/testVisitor';
 
 /**
  * Contains a collection of tests and of test suites.
  */
-export class TestSuite extends Map<string, Test | TestSuite> {
+export class TestSuiteInstance extends Map<string, TestInstance | TestSuiteInstance> {
 
     public name: string;
     public status: TestStatus;
     public context: any;
-    public tests: TestSuite;
+    public tests: TestSuiteInstance;
     public beforeAllMethods: Array<() => any> = [];
     public beforeEachMethods: Array<() => any> = [];
     public afterEachMethods: Array<() => any> = [];
@@ -24,7 +24,7 @@ export class TestSuite extends Map<string, Test | TestSuite> {
      * If it is a testsuite, all its children will be normalized.
      * @param key The test's id
      */
-    public get(key: string): Test | TestSuite {
+    public get(key: string): TestInstance | TestSuiteInstance {
         const test = super.get(key);
         if (test instanceof Map) {
             if (this.status !== TestStatus.Focused && this.hasFocusedTests()) {
@@ -35,7 +35,7 @@ export class TestSuite extends Map<string, Test | TestSuite> {
         }
 
         if (this.status !== TestStatus.Focused && test.status !== TestStatus.Focused && this.hasFocusedTests()) {
-            return new Test(test.name, test.func, TestStatus.Ignored);
+            return new TestInstance(test.name, test.func, TestStatus.Ignored);
         }
 
         return test;
@@ -45,7 +45,7 @@ export class TestSuite extends Map<string, Test | TestSuite> {
         return await visitor.visitTestSuite(this);
     }
 
-    private hasFocusedTests(testOrTestSuite: Test | TestSuite = this) {
+    private hasFocusedTests(testOrTestSuite: TestInstance | TestSuiteInstance = this) {
         if (testOrTestSuite.status === TestStatus.Focused) {
             return true;
         }
@@ -67,7 +67,7 @@ export class TestSuite extends Map<string, Test | TestSuite> {
     /**
      * Normalizes the test statuses. This means all tests which are not focused or under a focused test suite will be skipped.
      */
-    private getNormalizedCopy(): Test | TestSuite {
+    private getNormalizedCopy(): TestInstance | TestSuiteInstance {
         if (this.status === TestStatus.Focused) { return this; }
 
         const copy = this.clone();
@@ -77,15 +77,15 @@ export class TestSuite extends Map<string, Test | TestSuite> {
                 copy.set(id, testOrTestSuite.getNormalizedCopy());
             }
             else {
-                copy.set(id, new Test(testOrTestSuite.name, testOrTestSuite.func, testOrTestSuite.status === TestStatus.Focused ? TestStatus.Focused : TestStatus.Ignored));
+                copy.set(id, new TestInstance(testOrTestSuite.name, testOrTestSuite.func, testOrTestSuite.status === TestStatus.Focused ? TestStatus.Focused : TestStatus.Ignored));
             }
         }
 
         return copy;
     }
 
-    public clone(): TestSuite {
-        const copy = new TestSuite();
+    public clone(): TestSuiteInstance {
+        const copy = new TestSuiteInstance();
         copy.name = this.name;
         copy.status = this.status;
         copy.context = this.context;

--- a/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
+++ b/src/lib/tests/visitors/decorators/loggerTestReporterDecorator.ts
@@ -3,8 +3,8 @@ import { CompositeReport } from '../../../reporting/report/compositeReport';
 import { FailedTestReport } from '../../../reporting/report/failedTestReport';
 import { Report } from '../../../reporting/report/report';
 import { TestResult } from '../../../reporting/report/testResult';
-import { Test } from '../../test';
-import { TestSuite } from '../../testSuite';
+import { TestInstance } from '../../test';
+import { TestSuiteInstance } from '../../testSuite';
 import { TestVisitor } from '../testVisitor';
 import { TestsVisitorDecorator } from './testsVisitorDecorator';
 import { RootTestSuite } from '../../rootTestSuite';
@@ -15,7 +15,7 @@ export class LoggerTestReporterDecorator extends TestsVisitorDecorator<Report> {
         super(baseVisitor);
     }
 
-    public async visitTest(test: Test): Promise<Report> {
+    public async visitTest(test: TestInstance): Promise<Report> {
         const report = await this.baseVisitTest(test);
 
         if (report.result === TestResult.Success) {
@@ -31,7 +31,7 @@ export class LoggerTestReporterDecorator extends TestsVisitorDecorator<Report> {
         return report;
     }
 
-    public async visitTestSuite(tests: TestSuite): Promise<Report> {
+    public async visitTestSuite(tests: TestSuiteInstance): Promise<Report> {
         this.logger.info(tests.name);
         this.logger.increaseIndentation();
 

--- a/src/lib/tests/visitors/decorators/testsVisitorDecorator.ts
+++ b/src/lib/tests/visitors/decorators/testsVisitorDecorator.ts
@@ -1,11 +1,11 @@
 import { TestVisitor } from '../testVisitor';
-import { Test } from '../../test';
-import { TestSuite } from '../../testSuite';
+import { TestInstance } from '../../test';
+import { TestSuiteInstance } from '../../testSuite';
 import { RootTestSuite } from '../../rootTestSuite';
 
 export abstract class TestsVisitorDecorator<T> implements TestVisitor<T> {
-    protected baseVisitTest: (testSuite: Test) => Promise<T>;
-    protected baseVisitTestSuite: (testSuite: TestSuite) => Promise<T>;
+    protected baseVisitTest: (testSuite: TestInstance) => Promise<T>;
+    protected baseVisitTestSuite: (testSuite: TestSuiteInstance) => Promise<T>;
 
     constructor(private baseVisitor: TestVisitor<T>) {
         this.baseVisitTest = baseVisitor.visitTest.bind(baseVisitor);
@@ -15,7 +15,7 @@ export abstract class TestsVisitorDecorator<T> implements TestVisitor<T> {
         this.baseVisitor.visitTestSuite = this.visitTestSuite.bind(this);
     }
 
-    abstract visitTest(test: Test): Promise<T>;
-    abstract visitTestSuite(test: TestSuite): Promise<T>;
+    abstract visitTest(test: TestInstance): Promise<T>;
+    abstract visitTestSuite(test: TestSuiteInstance): Promise<T>;
     abstract visitRootTestSuite(test: RootTestSuite): Promise<T>;
 }

--- a/src/lib/tests/visitors/failedTestsReportVisitor.ts
+++ b/src/lib/tests/visitors/failedTestsReportVisitor.ts
@@ -1,7 +1,7 @@
 import { TestVisitor } from './testVisitor';
 import { Report } from '../../reporting/report/report';
-import { Test } from '../test';
-import { TestSuite } from '../testSuite';
+import { TestInstance } from '../test';
+import { TestSuiteInstance } from '../testSuite';
 import { CompositeReport } from '../../reporting/report/compositeReport';
 import { TestStatus } from '../../testStatus';
 import { SkippedTestReport } from '../../reporting/report/skippedTestReport';
@@ -12,7 +12,7 @@ import { RootTestSuite } from '../rootTestSuite';
 export class FailedTestsReportVisitor implements TestVisitor<Report> {
     constructor(private reason: string) { }
 
-    public async visitTest(test: Test): Promise<Report> {
+    public async visitTest(test: TestInstance): Promise<Report> {
         const report: LeafReport = test.status === TestStatus.Ignored
             ? new SkippedTestReport(test.name)
             : new FailedTestReport(test.name, this.reason, 0);
@@ -20,7 +20,7 @@ export class FailedTestsReportVisitor implements TestVisitor<Report> {
         return report;
     }
 
-    public async visitTestSuite(tests: TestSuite): Promise<Report> {
+    public async visitTestSuite(tests: TestSuiteInstance): Promise<Report> {
         const report = new CompositeReport(tests.name);
 
         for (const id of tests.testIds) {

--- a/src/lib/tests/visitors/testRunnerVisitor.ts
+++ b/src/lib/tests/visitors/testRunnerVisitor.ts
@@ -1,5 +1,5 @@
-import { TestSuite } from '../testSuite';
-import { Test } from '../test';
+import { TestSuiteInstance } from '../testSuite';
+import { TestInstance } from '../test';
 import { SuccessfulTestReport } from '../../reporting/report/successfulTestReport';
 import { FailedTestReport } from '../../reporting/report/failedTestReport';
 import { TestStatus } from '../../testStatus';
@@ -12,11 +12,11 @@ import { TestVisitor } from './testVisitor';
 import { RootTestSuite } from '../rootTestSuite';
 
 export class TestRunnerVisitor implements TestVisitor<Report> {
-    private testSuites: TestSuite[] = [];
+    private testSuites: TestSuiteInstance[] = [];
 
     constructor() { }
 
-    public async visitTestSuite(tests: TestSuite): Promise<Report> {
+    public async visitTestSuite(tests: TestSuiteInstance): Promise<Report> {
         this.testSuites.push(tests);
 
         const report = new CompositeReport(tests.name);
@@ -37,7 +37,7 @@ export class TestRunnerVisitor implements TestVisitor<Report> {
         return report;
     }
 
-    public async visitTest(test: Test): Promise<Report> {
+    public async visitTest(test: TestInstance): Promise<Report> {
         let report: LeafReport;
 
         if (test.status === TestStatus.Ignored) {
@@ -59,10 +59,10 @@ export class TestRunnerVisitor implements TestVisitor<Report> {
         return report;
     }
 
-    private async runTests(tests: TestSuite, report: CompositeReport): Promise<void> {
+    private async runTests(tests: TestSuiteInstance, report: CompositeReport): Promise<void> {
         for (const id of tests.testIds) {
             const test = tests.get(id);
-            const testReport = await (test as Test).accept<Report>(this);
+            const testReport = await (test as TestInstance).accept<Report>(this);
             report.addReport(testReport);
         }
     }

--- a/src/lib/tests/visitors/testVisitor.ts
+++ b/src/lib/tests/visitors/testVisitor.ts
@@ -1,9 +1,9 @@
-import { Test } from '../test';
-import { TestSuite } from '../testSuite';
+import { TestInstance } from '../test';
+import { TestSuiteInstance } from '../testSuite';
 import { RootTestSuite } from '../rootTestSuite';
 
 export interface TestVisitor<T> {
-    visitTest(test: Test): Promise<T>;
-    visitTestSuite(testSuite: TestSuite): Promise<T>;
+    visitTest(test: TestInstance): Promise<T>;
+    visitTestSuite(testSuite: TestSuiteInstance): Promise<T>;
     visitRootTestSuite(testSuite: RootTestSuite): Promise<T>;
 }

--- a/src/lib/utils/testsLoader.ts
+++ b/src/lib/utils/testsLoader.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as tsnode from 'ts-node';
 import { Logger } from '../logger/logger';
 import { RootTestSuite } from '../tests/rootTestSuite';
-import { TestSuite } from '../tests/testSuite';
+import { TestSuiteInstance } from '../tests/testSuite';
 
 export class TestsLoader {
 
@@ -11,7 +11,7 @@ export class TestsLoader {
 
     constructor(private logger?: Logger) { }
 
-    public async loadTests(root: string, patterns: string[], tsconfig: tsnode.Options): Promise<TestSuite> {
+    public async loadTests(root: string, patterns: string[], tsconfig: tsnode.Options): Promise<TestSuiteInstance> {
         this.registerTranspiler(tsconfig);
 
         const testSuites = new RootTestSuite();
@@ -24,11 +24,11 @@ export class TestsLoader {
         return testSuites;
     }
 
-    private async getTestInstancesFromFile(file: string): Promise<TestSuite[]> {
-        const testSuiteInstances: TestSuite[] = [];
+    private async getTestInstancesFromFile(file: string): Promise<TestSuiteInstance[]> {
+        const testSuiteInstances: TestSuiteInstance[] = [];
         const importedFile = await import(file);
         for (const key in importedFile) {
-            const testSuiteInstance: TestSuite = importedFile[key].__testSuiteInstance;
+            const testSuiteInstance: TestSuiteInstance = importedFile[key].__testSuiteInstance;
             if (!testSuiteInstance)
                 continue;
 

--- a/src/spec/assertion/arraysToBeEqual.spec.ts
+++ b/src/spec/assertion/arraysToBeEqual.spec.ts
@@ -1,9 +1,9 @@
-import { test, testSuite, expect, TestCase } from '../../testyCore';
+import { Test, TestSuite, expect, TestCase } from '../../testyCore';
 
-@testSuite('Expect ArraysToBeEqual Test Suite')
+@TestSuite('Expect ArraysToBeEqual Test Suite')
 export class ExpectArraysToBeEqualTestSuite {
 
-    @test('Arrays to be equal', [
+    @Test('Arrays to be equal', [
         new TestCase(`'a, b, c' and 'a, b, c'`, ['a', 'b', 'c'], ['a', 'b', 'c']),
         new TestCase(`empty arrays`, [], []),
         new TestCase(`arrays with undefined values`, [undefined, undefined], [undefined, undefined]),
@@ -12,7 +12,7 @@ export class ExpectArraysToBeEqualTestSuite {
         expect.arraysToBeEqual(actual, expected);
     }
 
-    @test('Arrays to be equal, should fail', [
+    @Test('Arrays to be equal, should fail', [
         new TestCase(`'a, b, c' to equal 'b, c, a'`, ['a', 'b', 'c'], ['b', 'c', 'a']),
         new TestCase(`different lengths`, ['a', 'b', 'c', 'd'], ['a', 'b', 'c']),
         new TestCase(`different lengths, but the other way around`, ['a', 'b', 'c'], ['a', 'b', 'c', 'd']),

--- a/src/spec/assertion/toBeDefined.spec.ts
+++ b/src/spec/assertion/toBeDefined.spec.ts
@@ -1,28 +1,28 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 
-@testSuite('Expect ToBeDefined Test Suite')
+@TestSuite('Expect ToBeDefined Test Suite')
 export class ExpectToBeDefinedTestSuite {
 
-    @test(`'a' to be defined`)
+    @Test(`'a' to be defined`)
     private aToBeDefined() {
         expect.toBeDefined('a');
     }
 
-    @test(`undefined to be defined to fail`)
+    @Test(`undefined to be defined to fail`)
     private undefinedToBeDefinedToFail() {
         expect.toThrow(() => {
             expect.toBeDefined(undefined);
         });
     }
 
-    @test(`'a' not to be defined to fail`)
+    @Test(`'a' not to be defined to fail`)
     private aNotToBeDefinedToFail() {
         expect.toThrow(() => {
             expect.not.toBeDefined('a');
         });
     }
 
-    @test(`undefined not to be defined`)
+    @Test(`undefined not to be defined`)
     private undefinedNotToBeDefinedToFail() {
         expect.not.toBeDefined(undefined);
     }

--- a/src/spec/assertion/toBeEqual.spec.ts
+++ b/src/spec/assertion/toBeEqual.spec.ts
@@ -1,26 +1,26 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 
-@testSuite('Expect ToBeEqual Test Suite')
+@TestSuite('Expect ToBeEqual Test Suite')
 export class ExpectToBeEqualTestSuite {
 
-    @test(`'a' to equal 'a'`)
+    @Test(`'a' to equal 'a'`)
     private equal() {
         expect.toBeEqual('a', 'a');
     }
 
-    @test(`'a' not to equal 'b'`)
+    @Test(`'a' not to equal 'b'`)
     private notEqual() {
         expect.not.toBeEqual('a', 'b');
     }
 
-    @test(`'a' to equal 'b' to fail`)
+    @Test(`'a' to equal 'b' to fail`)
     private equalFails() {
         expect.toThrow(() => {
             expect.toBeEqual('a', 'b');
         });
     }
 
-    @test(`'a' not to equal 'a' to fail`)
+    @Test(`'a' not to equal 'a' to fail`)
     private notEqualFails() {
         expect.toThrow(() => {
             expect.not.toBeEqual('a', 'a');

--- a/src/spec/assertion/toBeFalse.spec.ts
+++ b/src/spec/assertion/toBeFalse.spec.ts
@@ -1,22 +1,22 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 import { TestCase } from '../../lib/testCase';
 
-@testSuite('Expect ToBeFalse Test Suite')
+@TestSuite('Expect ToBeFalse Test Suite')
 export class ExpectToBeFalseTestSuite {
 
-    @test('false to be false, should succeed')
+    @Test('false to be false, should succeed')
     private falseToBeFalse() {
         expect.toBeFalse(false);
     }
 
-    @test('false not to be false, should fail')
+    @Test('false not to be false, should fail')
     private falseNotToBeFalseFail() {
         expect.toThrow(() => {
             expect.not.toBeFalse(false);
         });
     }
 
-    @test('To be false, should fail', [
+    @Test('To be false, should fail', [
         new TestCase('true', true),
         new TestCase('undefined', undefined),
         new TestCase('null', null),
@@ -30,7 +30,7 @@ export class ExpectToBeFalseTestSuite {
         });
     }
 
-    @test('Not to be false, should succeed', [
+    @Test('Not to be false, should succeed', [
         new TestCase('true', true),
         new TestCase('undefined', undefined),
         new TestCase('null', null),

--- a/src/spec/assertion/toBeFalsy.spec.ts
+++ b/src/spec/assertion/toBeFalsy.spec.ts
@@ -1,10 +1,10 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 import { TestCase } from '../../lib/testCase';
 
-@testSuite('Expect ToBeFalsy Tests')
+@TestSuite('Expect ToBeFalsy Tests')
 export class ExpectToBeFalsy {
 
-    @test('To be falsy, should succeed', [
+    @Test('To be falsy, should succeed', [
         new TestCase('false', false),
         new TestCase('zero', 0),
         new TestCase('empty string', ''),
@@ -16,7 +16,7 @@ export class ExpectToBeFalsy {
         expect.toBeFalsy(arg);
     }
 
-    @test('To be falsy, should fail', [
+    @Test('To be falsy, should fail', [
         new TestCase('true', true),
         new TestCase(`'0'`, '0'),
         new TestCase('Object', { a: 1 })
@@ -27,7 +27,7 @@ export class ExpectToBeFalsy {
         });
     }
 
-    @test('Not to be falsy, should succeed', [
+    @Test('Not to be falsy, should succeed', [
         new TestCase('true', true),
         new TestCase(`'0'`, '0'),
         new TestCase('Object', { a: 1 }),
@@ -36,7 +36,7 @@ export class ExpectToBeFalsy {
         expect.not.toBeFalsy(arg);
     }
 
-    @test('Not to be falsy, should fail', [
+    @Test('Not to be falsy, should fail', [
         new TestCase('false', false),
         new TestCase('zero', 0),
         new TestCase('empty string', ''),

--- a/src/spec/assertion/toBeIn.spec.ts
+++ b/src/spec/assertion/toBeIn.spec.ts
@@ -1,28 +1,28 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 
-@testSuite('Expect ToBeIn Tests')
+@TestSuite('Expect ToBeIn Tests')
 export class ExpectToMatch {
 
-    @test(`'a' to be in, should succeed`)
+    @Test(`'a' to be in, should succeed`)
     private aToBeInSuccess() {
         expect.toBeIn('a', ['a', 'b', 'c']);
     }
 
-    @test(`'a' to be in, should fail`)
+    @Test(`'a' to be in, should fail`)
     private aToBeInFail() {
         expect.toThrow(() => {
             expect.toBeIn('a', ['b', 'c', 'd']);
         });
     }
 
-    @test(`'a' not to be in, should fail`)
+    @Test(`'a' not to be in, should fail`)
     private aNotToBeInFail() {
         expect.toThrow(() => {
             expect.not.toBeIn('a', ['a', 'b', 'c']);
         });
     }
 
-    @test(`'a' not to be in, should succeed`)
+    @Test(`'a' not to be in, should succeed`)
     private aNotToBeInSuccess() {
         expect.not.toBeIn('a', ['b', 'c', 'd']);
     }

--- a/src/spec/assertion/toBeSortedInAscendingOrder.spec.ts
+++ b/src/spec/assertion/toBeSortedInAscendingOrder.spec.ts
@@ -1,21 +1,21 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 
-@testSuite('Expect ToBeSorted InAscendingOrder Tests')
+@TestSuite('Expect ToBeSorted InAscendingOrder Tests')
 export class ExpectToBeOrdered {
 
-    @test('ordered numbers to be ordered')
+    @Test('ordered numbers to be ordered')
     private orderedNumbersToBeOrdered() {
         expect.toBeSorted.inAscendingOrder([-1, 2, 2, 5, 7, 100]);
     }
 
-    @test('unordered numbers to be ordered to fail')
+    @Test('unordered numbers to be ordered to fail')
     private unorderedNumbersToBeOrderedFails() {
         expect.toThrow(() => {
             expect.toBeSorted.inAscendingOrder([100, 5, 2, -1, -10]);
         });
     }
 
-    @test('ordered objects array to be ordered')
+    @Test('ordered objects array to be ordered')
     private orderedObjectsToBeOrdered() {
         expect.toBeSorted.inAscendingOrder(
             [
@@ -27,7 +27,7 @@ export class ExpectToBeOrdered {
             x => x.a);
     }
 
-    @test('unordered objects array to be ordered, fails')
+    @Test('unordered objects array to be ordered, fails')
     private unorderedObjectsToBeOrderedFails() {
         expect.toThrow(() => {
             expect.toBeSorted.inAscendingOrder(
@@ -41,19 +41,19 @@ export class ExpectToBeOrdered {
         });
     }
 
-    @test('ordered numbers not to be ordered to fail')
+    @Test('ordered numbers not to be ordered to fail')
     private orderedNumbersNotToBeOrderedFails() {
         expect.toThrow(() => {
             expect.not.toBeSorted.inAscendingOrder([-1, 2, 2, 5, 7, 100]);
         });
     }
 
-    @test('unordered numbers not to be ordered')
+    @Test('unordered numbers not to be ordered')
     private unorderedNumbersNotToBeOrderedFails() {
         expect.not.toBeSorted.inAscendingOrder([100, 5, 2, -1, -10]);
     }
 
-    @test('ordered objects array not to be ordered')
+    @Test('ordered objects array not to be ordered')
     private orderedObjectsNotToBeOrdered() {
         expect.toThrow(() => {
             expect.not.toBeSorted.inAscendingOrder(
@@ -67,7 +67,7 @@ export class ExpectToBeOrdered {
         });
     }
 
-    @test('unordered objects array not to be ordered')
+    @Test('unordered objects array not to be ordered')
     private unorderedObjectsNotToBeOrdered() {
         expect.not.toBeSorted.inAscendingOrder(
             [

--- a/src/spec/assertion/toBeSortedInDescendingOrder.spec.ts
+++ b/src/spec/assertion/toBeSortedInDescendingOrder.spec.ts
@@ -1,28 +1,28 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 
-@testSuite('Expect ToBeSorted InDescendingOrder Tests')
+@TestSuite('Expect ToBeSorted InDescendingOrder Tests')
 export class ExpectToBeOrdered {
 
-    @test('ordered numbers to be ordered')
+    @Test('ordered numbers to be ordered')
     private orderedNumbersToBeOrdered() {
         expect.toBeSorted.inDescendingOrder([100, 5, 2, 2, -1, -10]);
     }
 
-    @test('unordered numbers to be ordered to fail')
+    @Test('unordered numbers to be ordered to fail')
     private unoderedNumbersToBeOrderedFails() {
         expect.toThrow(() => {
             expect.toBeSorted.inDescendingOrder([-1, 2, 5, 7, 100]);
         });
     }
 
-    @test('unordered numbers array to fail')
+    @Test('unordered numbers array to fail')
     private unorderedNumbersToBeOrdered() {
         expect.toThrow(() => {
             expect.toBeSorted.inDescendingOrder([3, 2, -1, 4, 5]);
         });
     }
 
-    @test('ordered objects array to be ordered')
+    @Test('ordered objects array to be ordered')
     private orderedObjectsToBeOrdered() {
         expect.toBeSorted.inDescendingOrder(
             [
@@ -34,7 +34,7 @@ export class ExpectToBeOrdered {
             x => x.a);
     }
 
-    @test('unordered objects array to fail')
+    @Test('unordered objects array to fail')
     private unorderedObjectsToBeOrderedFails() {
         expect.toThrow(() => {
             expect.toBeSorted.inDescendingOrder(
@@ -48,19 +48,19 @@ export class ExpectToBeOrdered {
         });
     }
 
-    @test('ordered numbers not to be ordered, fails')
+    @Test('ordered numbers not to be ordered, fails')
     private orderedNumbersNotToBeOrderedFails() {
         expect.toThrow(() => {
             expect.not.toBeSorted.inDescendingOrder([100, 5, 2, 2, -1, -10]);
         });
     }
 
-    @test('unordered numbers not to be ordered')
+    @Test('unordered numbers not to be ordered')
     private unoderedNumberNotsToBeOrdered() {
         expect.not.toBeSorted.inDescendingOrder([-1, 2, -29, 7, 100]);
     }
 
-    @test('ordered objects array not to be ordered, fails')
+    @Test('ordered objects array not to be ordered, fails')
     private orderedObjectsNotToBeOrderedFails() {
         expect.toThrow(() => {
             expect.not.toBeSorted.inDescendingOrder(
@@ -74,7 +74,7 @@ export class ExpectToBeOrdered {
         });
     }
 
-    @test('unordered objects array to be ordered')
+    @Test('unordered objects array to be ordered')
     private unorderedObjectsNotToBeOrdered() {
         expect.not.toBeSorted.inDescendingOrder(
             [

--- a/src/spec/assertion/toBeTrue.spec.ts
+++ b/src/spec/assertion/toBeTrue.spec.ts
@@ -1,21 +1,21 @@
-import { test, testSuite, expect, TestCase } from '../../testyCore';
+import { Test, TestSuite, expect, TestCase } from '../../testyCore';
 
-@testSuite('Expect ToBeTrue Tests')
+@TestSuite('Expect ToBeTrue Tests')
 export class ExpectToBeTrue {
 
-    @test('true to be true')
+    @Test('true to be true')
     private trueToBeTrue() {
         expect.toBeTrue(true);
     }
 
-    @test('true not to be true to fail')
+    @Test('true not to be true to fail')
     private trueNotToBeTrue() {
         expect.toThrow(() => {
             expect.not.toBeTrue(true);
         });
     }
 
-    @test('To be true, should fail', [
+    @Test('To be true, should fail', [
         new TestCase('false', false),
         new TestCase('undefined', undefined),
         new TestCase('null', null),
@@ -26,7 +26,7 @@ export class ExpectToBeTrue {
         });
     }
 
-    @test('Not to be true, should succeed', [
+    @Test('Not to be true, should succeed', [
         new TestCase('false', false),
         new TestCase('undefined', undefined),
         new TestCase('null', null),

--- a/src/spec/assertion/toBeTruthy.spec.ts
+++ b/src/spec/assertion/toBeTruthy.spec.ts
@@ -1,9 +1,9 @@
-import { test, testSuite, expect, TestCase } from '../../testyCore';
+import { Test, TestSuite, expect, TestCase } from '../../testyCore';
 
-@testSuite('Expect ToBeTruthy Tests')
+@TestSuite('Expect ToBeTruthy Tests')
 export class ExpectToBeTruthy {
 
-    @test('To be truthy, should succeed', [
+    @Test('To be truthy, should succeed', [
         new TestCase('true', true),
         new TestCase(`'0'`, '0'),
         new TestCase(`'false'`, 'false'),
@@ -15,7 +15,7 @@ export class ExpectToBeTruthy {
         expect.toBeTruthy(arg);
     }
 
-    @test('To be truthy, should fail', [
+    @Test('To be truthy, should fail', [
         new TestCase('false', false),
         new TestCase('zero', 0),
         new TestCase('empty string', ''),
@@ -29,7 +29,7 @@ export class ExpectToBeTruthy {
         });
     }
 
-    @test('Not to be truthy, should fail', [
+    @Test('Not to be truthy, should fail', [
         new TestCase('true', true),
         new TestCase(`'0'`, '0'),
         new TestCase(`'false'`, 'false'),
@@ -43,7 +43,7 @@ export class ExpectToBeTruthy {
         });
     }
 
-    @test('Not to be truthy, should succeed', [
+    @Test('Not to be truthy, should succeed', [
         new TestCase('false', false),
         new TestCase('zero', 0),
         new TestCase('empty string', ''),

--- a/src/spec/assertion/toMatch.spec.ts
+++ b/src/spec/assertion/toMatch.spec.ts
@@ -1,27 +1,27 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 
-@testSuite('Expect ToMatch Tests')
+@TestSuite('Expect ToMatch Tests')
 export class ExpectToMatch {
-    @test(`'hello' to match /[a-z]/, should succeed`)
+    @Test(`'hello' to match /[a-z]/, should succeed`)
     private helloToMatchSuccess() {
         expect.toMatch('hello', /[a-z]/);
     }
 
-    @test(`'hello' to match /[A-Z]/, should fail`)
+    @Test(`'hello' to match /[A-Z]/, should fail`)
     private helloToMatchFail() {
         expect.toThrow(() => {
             expect.toMatch('hello', /[A-Z]/);
         });
     }
 
-    @test(`'hello' not to match /[a-z]/, should fail`)
+    @Test(`'hello' not to match /[a-z]/, should fail`)
     private helloNotToMatchFail() {
         expect.toThrow(() => {
             expect.not.toMatch('hello', /[a-z]/);
         });
     }
 
-    @test(`'hello' not to match /[A-Z]/, should fail`)
+    @Test(`'hello' not to match /[A-Z]/, should fail`)
     private helloNotToMatchSuccess() {
         expect.not.toMatch('hello', /[A-Z]/);
     }

--- a/src/spec/assertion/toThrow.spec.ts
+++ b/src/spec/assertion/toThrow.spec.ts
@@ -1,23 +1,23 @@
-import { test, testSuite, expect } from '../../testyCore';
+import { Test, TestSuite, expect } from '../../testyCore';
 
-@testSuite('Expect ToThrow Test Suite')
+@TestSuite('Expect ToThrow Test Suite')
 export class ExpectToThrowTestSuite {
 
-    @test('error to throw')
+    @Test('error to throw')
     private errorToThrow() {
         expect.toThrow(() => {
             throw new Error('I threw.');
         });
     }
 
-    @test('no error to throw to fail')
+    @Test('no error to throw to fail')
     private noErrorToThrowToFail() {
         expect.toThrow(() => {
             expect.toThrow(() => { });
         });
     }
 
-    @test('error not to throw to fail')
+    @Test('error not to throw to fail')
     private errorNotToThrowToFail() {
         expect.toThrow(() => {
             expect.not.toThrow(() => {
@@ -26,26 +26,26 @@ export class ExpectToThrowTestSuite {
         });
     }
 
-    @test('no error not to throw')
+    @Test('no error not to throw')
     private noErrorNotToThrow() {
         expect.not.toThrow(() => { });
     }
 
-    @test('error to throw async')
+    @Test('error to throw async')
     private async errorToThrowAsync() {
         await expect.toThrowAsync(async () => {
             throw new Error('I threw.');
         });
     }
 
-    @test('no error to throw to fail async')
+    @Test('no error to throw to fail async')
     private async noErrorToThrowToFailAsync() {
         await expect.toThrowAsync(async () => {
             await expect.toThrowAsync(async () => Promise.resolve(21));
         });
     }
 
-    @test('error not to throw to fail async')
+    @Test('error not to throw to fail async')
     private async errorNotToThrowToFailAsync() {
         await expect.toThrow(() => {
             expect.not.toThrow(() => {
@@ -54,7 +54,7 @@ export class ExpectToThrowTestSuite {
         });
     }
 
-    @test('no error not to throw async')
+    @Test('no error not to throw async')
     private async noErrorNotToThrowAsync() {
         await expect.not.toThrow(async () => Promise.resolve(53));
     }

--- a/src/spec/cli/cli.spec.ts
+++ b/src/spec/cli/cli.spec.ts
@@ -1,23 +1,23 @@
-import { testSuite, beforeEach, test, TestCase, expect } from '../../testyCore';
+import { TestSuite, BeforeEach, Test, TestCase, expect } from '../../testyCore';
 import { Logger } from '../../lib/logger/logger';
 import { TestyCli } from '../../lib/cli/testyCli';
 import { NullLogger } from '../utils/nullLogger';
 import { RunCommand } from '../../lib/cli/run.command';
 import { InitCommand } from '../../lib/cli/init.command';
 
-@testSuite('Cli Tests')
+@TestSuite('Cli Tests')
 export class CliTests {
 
     private logger: Logger;
     private cli: TestyCli;
 
-    @beforeEach()
+    @BeforeEach()
     private beforeEach() {
         this.logger = new NullLogger();
         this.cli = new TestyCli(this.logger);
     }
 
-    @test('Run command', [
+    @Test('Run command', [
         new TestCase('testy', ['node', '/some/path'], 'testy.json'),
         new TestCase('testy -c alternate/config.json', ['node', '/some/path', '-c', 'alternate/config.json'], 'alternate/config.json'),
         new TestCase('testy --config alternate/config.json', ['node', '/some/path', '--config', 'alternate/config.json'], 'alternate/config.json'),
@@ -32,7 +32,7 @@ export class CliTests {
         expect.toBeEqual(runCommand.testyConfigFile, expectedConfig);
     }
 
-    @test('testy init')
+    @Test('testy init')
     private async initCommandTests() {
         // Arrange
         const args = ['node', '/some/path', 'init'];

--- a/src/spec/decorators/baseTestSuite/baseWithChildren.ts
+++ b/src/spec/decorators/baseTestSuite/baseWithChildren.ts
@@ -1,16 +1,16 @@
-import { testSuite, test } from '../../../testyCore';
-import { beforeEach } from '../../../lib/decorators/afterAndBefore.decorator';
+import { TestSuite, Test } from '../../../testyCore';
+import { BeforeEach } from '../../../lib/decorators/afterAndBefore.decorator';
 
 class Base {
-    @beforeEach() beforeEach() { }
+    @BeforeEach() beforeEach() { }
 }
 
-@testSuite()
+@TestSuite()
 export class TestSuiteA extends Base {
-    @test() testA() { }
+    @Test() testA() { }
 }
 
-@testSuite()
+@TestSuite()
 export class TestSuiteB extends Base {
-    @test() testB() { }
+    @Test() testB() { }
 }

--- a/src/spec/decorators/baseTestSuite/testSuiteWithBase.ts
+++ b/src/spec/decorators/baseTestSuite/testSuiteWithBase.ts
@@ -1,5 +1,5 @@
-import { test, beforeAll, beforeEach, afterEach, afterAll } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test, BeforeAll, BeforeEach, AfterEach, AfterAll } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
 export class BaseTestSuite {
     public beforeAllExecuted = [];
@@ -7,49 +7,49 @@ export class BaseTestSuite {
     public afterAllExecuted = [];
     public afterEachExecuted = [];
 
-    @beforeAll()
+    @BeforeAll()
     private beforeAllBase() {
         this.beforeAllExecuted.push(BaseTestSuite);
     }
 
-    @beforeEach()
+    @BeforeEach()
     private beforeEachBase() {
         this.beforeEachExecuted.push(BaseTestSuite);
     }
 
-    @afterEach()
+    @AfterEach()
     private afterEachBase() {
         this.afterEachExecuted.push(BaseTestSuite);
     }
 
-    @afterAll()
+    @AfterAll()
     private afterAllBase() {
         this.afterAllExecuted.push(BaseTestSuite);
     }
 }
 
-@testSuite('Test Suite')
+@TestSuite('Test Suite')
 export class TestSuiteWithBase extends BaseTestSuite {
-    @beforeAll()
+    @BeforeAll()
     private beforeAll() {
         this.beforeAllExecuted.push(TestSuiteWithBase);
     }
 
-    @beforeEach()
+    @BeforeEach()
     private beforeEach() {
         this.beforeEachExecuted.push(TestSuiteWithBase);
     }
 
-    @afterEach()
+    @AfterEach()
     private afterEach() {
         this.afterEachExecuted.push(TestSuiteWithBase);
     }
 
-    @afterAll()
+    @AfterAll()
     private afterAll() {
         this.afterAllExecuted.push(TestSuiteWithBase);
     }
 
-    @test('Test')
+    @Test('Test')
     private test() { }
 }

--- a/src/spec/decorators/baseTestSuite/testWithBase.spec.ts
+++ b/src/spec/decorators/baseTestSuite/testWithBase.spec.ts
@@ -1,12 +1,12 @@
-import { testSuite, test, expect, ftest } from '../../../testyCore';
+import { TestSuite, Test, expect } from '../../../testyCore';
 import { TestSuiteTestsBase } from '../testSuiteTestsBase';
 import { TestSuiteWithBase, BaseTestSuite } from './testSuiteWithBase';
 import { TestSuiteA, TestSuiteB } from './baseWithChildren';
 
-@testSuite('Test Suite With Base Test Suite Tests')
+@TestSuite('Test Suite With Base Test Suite Tests')
 export class BeforeAfterDecoratorsTestSuite extends TestSuiteTestsBase {
 
-    @test('the base and the actual test suite before and after methods are called.')
+    @Test('the base and the actual test suite before and after methods are called.')
     private async trivialCase() {
         // Arrange
         const testSuite = this.getTestSuiteInstance(TestSuiteWithBase);
@@ -25,7 +25,7 @@ export class BeforeAfterDecoratorsTestSuite extends TestSuiteTestsBase {
         expect.toBeEqual(testSuite.context.afterAllExecuted[1], TestSuiteWithBase);
     }
 
-    @test('base with multiple children')
+    @Test('base with multiple children')
     private async baseWithMultipleChildren() {
         // Arrange
         const a = this.getTestSuiteInstance(TestSuiteA);

--- a/src/spec/decorators/beforeAfterDecorators/beforeAfterDecorators.spec.ts
+++ b/src/spec/decorators/beforeAfterDecorators/beforeAfterDecorators.spec.ts
@@ -1,4 +1,4 @@
-import { testSuite, beforeEach, test, expect, TestCase, TestResult } from '../../../testyCore';
+import { TestSuite, BeforeEach, Test, expect, TestCase, TestResult } from '../../../testyCore';
 import { TestVisitor } from '../../../lib/tests/visitors/testVisitor';
 import { Report } from '../../../lib/reporting/report/report';
 import { TestRunnerVisitor } from '../../../lib/tests/visitors/testRunnerVisitor';
@@ -7,20 +7,20 @@ import { ThrowsDuringBeforeAllTestSuite } from './throwsDuringBeforeAllTestSuite
 import { ThrowsDuringBeforeEachTestSuite } from './throwsDuringBeforeEachTestSuite';
 import { ThrowsDuringAfterEachTestSuite } from './throwsDuringAfterEachTestSuite';
 import { ThrowsDuringAfterAllTestSuite } from './throwsDuringAfterAllTestSuite';
-import { TestSuite } from '../../../lib/tests/testSuite';
+import { TestSuiteInstance } from '../../../lib/tests/testSuite';
 
-@testSuite('Before and After Decorators Test Suite')
+@TestSuite('Before and After Decorators Test Suite')
 export class BeforeAfterDecoratorsTestSuite {
 
     // TODO: This test suite should extend TestSuiteTestsBase when #8 is fixed.
     protected visitor: TestVisitor<Report>;
 
-    @beforeEach()
+    @BeforeEach()
     private beforeEach() {
         this.visitor = new TestRunnerVisitor();
     }
 
-    @test('beforeAll, beforeEach, afterEach and afterAll are called the right amount of time.')
+    @Test('beforeAll, beforeEach, afterEach and afterAll are called the right amount of time.')
     private async trivialCase() {
         // Arrange
         const testSuite = this.getTestSuiteInstance(NormalBeforeAfterTestSuite);
@@ -36,7 +36,7 @@ export class BeforeAfterDecoratorsTestSuite {
         expect.toBeEqual(report.numberOfTests, 6);
     }
 
-    @test('Before and after methods failures', [
+    @Test('Before and after methods failures', [
         new TestCase('beforeAll throws, should return a failed test report', ThrowsDuringBeforeAllTestSuite, 6),
         new TestCase('beforeEach throws, should return a failed test report', ThrowsDuringBeforeEachTestSuite, 6),
         new TestCase('afterEach throws, should return a failed test report', ThrowsDuringAfterEachTestSuite, 6),
@@ -55,7 +55,7 @@ export class BeforeAfterDecoratorsTestSuite {
         expect.toBeEqual(report.numberOfTests, numberOfTests, 'Expected all tests to be part of the report.');
     }
 
-    protected getTestSuiteInstance(testClass: any): TestSuite {
+    protected getTestSuiteInstance(testClass: any): TestSuiteInstance {
         return testClass.__testSuiteInstance;
     }
 }

--- a/src/spec/decorators/beforeAfterDecorators/normalBeforeAfterTestSuite.ts
+++ b/src/spec/decorators/beforeAfterDecorators/normalBeforeAfterTestSuite.ts
@@ -1,40 +1,40 @@
-import { test, beforeAll, beforeEach, afterEach, afterAll, TestCase } from '../../../testyCore';
-import { xtest } from '../../../lib/decorators/test.decorator';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test, BeforeAll, BeforeEach, AfterEach, AfterAll, TestCase } from '../../../testyCore';
+import { XTest } from '../../../lib/decorators/test.decorator';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Normal Before After Test Suite')
+@TestSuite('Normal Before After Test Suite')
 export class NormalBeforeAfterTestSuite {
     public numberOfBeforeAllExecutions = 0;
     public numberOfBeforeEachExecutions = 0;
     public numberOfAfterEachExecutions = 0;
     public numberOfAfterAllExecutions = 0;
 
-    @beforeAll()
+    @BeforeAll()
     private beforeAll() { ++this.numberOfBeforeAllExecutions; }
 
-    @beforeEach()
+    @BeforeEach()
     private beforeEach() { ++this.numberOfBeforeEachExecutions; }
 
-    @afterEach()
+    @AfterEach()
     private afterEach() { ++this.numberOfAfterEachExecutions; }
 
-    @afterAll()
+    @AfterAll()
     private afterAll() { ++this.numberOfAfterAllExecutions; }
 
-    @test('a')
+    @Test('a')
     private a() { }
 
-    @test('b')
+    @Test('b')
     private b() { }
 
 
-    @test('c', [
+    @Test('c', [
         new TestCase('c.1'),
         new TestCase('c.2'),
         new TestCase('c.3'),
     ])
     private c() { }
 
-    @xtest('d')
+    @XTest('d')
     private d() { }
 }

--- a/src/spec/decorators/beforeAfterDecorators/throwsDuringAfterAllTestSuite.ts
+++ b/src/spec/decorators/beforeAfterDecorators/throwsDuringAfterAllTestSuite.ts
@@ -1,26 +1,26 @@
-import { test, xtest, afterAll, TestCase } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test, XTest, AfterAll, TestCase } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Throws During After All Test Suite ')
+@TestSuite('Throws During After All Test Suite ')
 export class ThrowsDuringAfterAllTestSuite {
-    @afterAll()
+    @AfterAll()
     private afterAll() {
         throw new Error('This should be handled.');
     }
 
-    @test('a')
+    @Test('a')
     private a() { }
 
-    @test('b')
+    @Test('b')
     private b() { }
 
-    @test('c', [
+    @Test('c', [
         new TestCase('c.1'),
         new TestCase('c.2'),
         new TestCase('c.3'),
     ])
     private c() { }
 
-    @xtest('d')
+    @XTest('d')
     private d() { }
 }

--- a/src/spec/decorators/beforeAfterDecorators/throwsDuringAfterEachTestSuite.ts
+++ b/src/spec/decorators/beforeAfterDecorators/throwsDuringAfterEachTestSuite.ts
@@ -1,26 +1,26 @@
-import { test, xtest, afterEach, TestCase } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test, XTest, AfterEach, TestCase } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Throws During After Each Test Suite')
+@TestSuite('Throws During After Each Test Suite')
 export class ThrowsDuringAfterEachTestSuite {
-    @afterEach()
+    @AfterEach()
     private afterEach() {
         throw new Error('This should be handled.');
     }
 
-    @test('a')
+    @Test('a')
     private a() { }
 
-    @test('b')
+    @Test('b')
     private b() { }
 
-    @test('c', [
+    @Test('c', [
         new TestCase('c.1'),
         new TestCase('c.2'),
         new TestCase('c.3'),
     ])
     private c() { }
 
-    @xtest('d')
+    @XTest('d')
     private d() { }
 }

--- a/src/spec/decorators/beforeAfterDecorators/throwsDuringBeforeAllTestSuite.ts
+++ b/src/spec/decorators/beforeAfterDecorators/throwsDuringBeforeAllTestSuite.ts
@@ -1,26 +1,26 @@
-import { test, xtest, beforeAll, TestCase } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test, XTest, BeforeAll, TestCase } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Throws During Before All Test Suite')
+@TestSuite('Throws During Before All Test Suite')
 export class ThrowsDuringBeforeAllTestSuite {
-    @beforeAll()
+    @BeforeAll()
     private beforeAll() {
         throw new Error('This should be handled.');
     }
 
-    @test('a')
+    @Test('a')
     private a() { }
 
-    @test('b')
+    @Test('b')
     private b() { }
 
-    @test('c', [
+    @Test('c', [
         new TestCase('c.1'),
         new TestCase('c.2'),
         new TestCase('c.3'),
     ])
     private c() { }
 
-    @xtest('d')
+    @XTest('d')
     private d() { }
 }

--- a/src/spec/decorators/beforeAfterDecorators/throwsDuringBeforeEachTestSuite.ts
+++ b/src/spec/decorators/beforeAfterDecorators/throwsDuringBeforeEachTestSuite.ts
@@ -1,25 +1,25 @@
-import { test, xtest, beforeEach, TestCase, testSuite } from '../../../testyCore';
+import { Test, XTest, BeforeEach, TestCase, TestSuite } from '../../../testyCore';
 
-@testSuite('Throws During Before Each Test Suite')
+@TestSuite('Throws During Before Each Test Suite')
 export class ThrowsDuringBeforeEachTestSuite {
-    @beforeEach()
+    @BeforeEach()
     private beforeEach() {
         throw new Error('This should be handled.');
     }
 
-    @test('a')
+    @Test('a')
     private a() { }
 
-    @test('b')
+    @Test('b')
     private b() { }
 
-    @test('c', [
+    @Test('c', [
         new TestCase('c.1'),
         new TestCase('c.2'),
         new TestCase('c.3'),
     ])
     private c() { }
 
-    @xtest('d')
+    @XTest('d')
     private d() { }
 }

--- a/src/spec/decorators/testDecorator/multipleTestsTestDecoratorTestSuite.ts
+++ b/src/spec/decorators/testDecorator/multipleTestsTestDecoratorTestSuite.ts
@@ -1,15 +1,15 @@
-import { test } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Multiple Test Test Decorator Test Suite')
+@TestSuite('Multiple Test Test Decorator Test Suite')
 export class MultipleTestTestDecoratorTestSuite {
 
-    @test('My first test')
+    @Test('My first test')
     private test1() { }
 
-    @test('My second test')
+    @Test('My second test')
     private test2() { }
 
-    @test('My third test')
+    @Test('My third test')
     private test3() { }
 }

--- a/src/spec/decorators/testDecorator/singleTestTestDecoratorTestSuite.ts
+++ b/src/spec/decorators/testDecorator/singleTestTestDecoratorTestSuite.ts
@@ -1,12 +1,12 @@
-import { test } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Single Test Test Decorator Test Suite')
+@TestSuite('Single Test Test Decorator Test Suite')
 export class SingleTestTestDecoratorTestSuite {
 
     public numberOfRunsTest1: number = 0;
 
-    @test('My single test')
+    @Test('My single test')
     private test1() {
         ++this.numberOfRunsTest1;
     }

--- a/src/spec/decorators/testDecorator/testCasesTestDecoratorTestSuite.ts
+++ b/src/spec/decorators/testDecorator/testCasesTestDecoratorTestSuite.ts
@@ -1,13 +1,13 @@
-import { test, TestCase, testSuite } from '../../../testyCore';
+import { Test, TestCase, TestSuite } from '../../../testyCore';
 
-@testSuite('TestCases Test Decorator Test Suite')
+@TestSuite('TestCases Test Decorator Test Suite')
 export class TestCasesTestDecoratorTestSuite {
 
     public numberOfRunsTest1: number = 0;
     public numberOfRunsTest2: number = 0;
     public numberOfRunsTest3: number = 0;
 
-    @test('My test with test cases', [
+    @Test('My test with test cases', [
         new TestCase('My first test', 1),
         new TestCase('My second test', 2),
         new TestCase('My third test', 3),

--- a/src/spec/decorators/testDecorator/testDecorator.spec.ts
+++ b/src/spec/decorators/testDecorator/testDecorator.spec.ts
@@ -1,14 +1,14 @@
-import { TestSuite } from '../../../lib/tests/testSuite';
-import { expect, test, testSuite } from '../../../testyCore';
+import { TestSuiteInstance } from '../../../lib/tests/testSuite';
+import { expect, Test, TestSuite } from '../../../testyCore';
 import { MultipleTestTestDecoratorTestSuite } from './multipleTestsTestDecoratorTestSuite';
 import { SingleTestTestDecoratorTestSuite } from './singleTestTestDecoratorTestSuite';
 import { TestCasesTestDecoratorTestSuite } from './testCasesTestDecoratorTestSuite';
 import { TestWithNoNamesTestSuite } from './testWithoutNames';
 
-@testSuite('Test Decorator Test Suite')
+@TestSuite('Test Decorator Test Suite')
 export class TestDecoratorTestSuite {
 
-    @test('single test, test should be ran once')
+    @Test('single test, test should be ran once')
     private singleTest() {
         // Arrange
         const testSuite = this.getTestSuiteInstance(SingleTestTestDecoratorTestSuite);
@@ -18,7 +18,7 @@ export class TestDecoratorTestSuite {
         expect.toBeIn('My single test', testSuite.testIds);
     }
 
-    @test('multiple test, tests should be ran once')
+    @Test('multiple test, tests should be ran once')
     private multipleTest() {
         // Arrange
         const testSuite = this.getTestSuiteInstance(MultipleTestTestDecoratorTestSuite);
@@ -30,7 +30,7 @@ export class TestDecoratorTestSuite {
         expect.toBeIn('My third test', testSuite.testIds);
     }
 
-    @test('test cases, tests should be ran once')
+    @Test('test cases, tests should be ran once')
     private testCasesTest() {
         // Arrange
         const testSuite = this.getTestSuiteInstance(TestCasesTestDecoratorTestSuite);
@@ -39,13 +39,13 @@ export class TestDecoratorTestSuite {
         expect.toBeEqual(testSuite.testIds.length, 1);
         expect.toBeIn('My test with test cases', testSuite.testIds);
 
-        const subTestSuite = testSuite.get('My test with test cases') as TestSuite;
+        const subTestSuite = testSuite.get('My test with test cases') as TestSuiteInstance;
         expect.toBeIn('My first test', subTestSuite.testIds);
         expect.toBeIn('My second test', subTestSuite.testIds);
         expect.toBeIn('My third test', subTestSuite.testIds);
     }
 
-    @test('no names, should infer from method names')
+    @Test('no names, should infer from method names')
     private noNameTest() {
         // Arrange
         const testSuite = this.getTestSuiteInstance(TestWithNoNamesTestSuite);
@@ -55,13 +55,13 @@ export class TestDecoratorTestSuite {
         expect.toBeIn('myTest2', testSuite.testIds);
         expect.toBeIn('myTest3', testSuite.testIds);
 
-        const myTest3 = testSuite.get('myTest3') as TestSuite;
+        const myTest3 = testSuite.get('myTest3') as TestSuiteInstance;
         expect.toBeIn('myTestCase1', myTest3.testIds);
         expect.toBeIn('myTestCase2', myTest3.testIds);
         expect.toBeIn('myTestCase3', myTest3.testIds);
     }
 
-    protected getTestSuiteInstance(testClass: any): TestSuite {
+    protected getTestSuiteInstance(testClass: any): TestSuiteInstance {
         return testClass.__testSuiteInstance;
     }
 }

--- a/src/spec/decorators/testDecorator/testWithoutNames.ts
+++ b/src/spec/decorators/testDecorator/testWithoutNames.ts
@@ -1,16 +1,16 @@
-import { test } from '../../../testyCore';
+import { Test } from '../../../testyCore';
 import { TestCase } from '../../../lib/testCase';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite()
+@TestSuite()
 export class TestWithNoNamesTestSuite {
-    @test()
+    @Test()
     private myTest1() { }
 
-    @test()
+    @Test()
     private myTest2() { }
 
-    @test(undefined, [
+    @Test(undefined, [
         new TestCase('myTestCase1'),
         new TestCase('myTestCase2'),
         new TestCase('myTestCase3')

--- a/src/spec/decorators/testSuiteTestsBase.ts
+++ b/src/spec/decorators/testSuiteTestsBase.ts
@@ -1,18 +1,18 @@
 import { Report } from '../../lib/reporting/report/report';
-import { TestSuite } from '../../lib/tests/testSuite';
+import { TestSuiteInstance } from '../../lib/tests/testSuite';
 import { TestVisitor } from '../../lib/tests/visitors/testVisitor';
 import { TestRunnerVisitor } from '../../lib/tests/visitors/testRunnerVisitor';
-import { beforeEach } from '../../lib/decorators/afterAndBefore.decorator';
+import { BeforeEach } from '../../lib/decorators/afterAndBefore.decorator';
 
 export class TestSuiteTestsBase {
     protected visitor: TestVisitor<Report>;
 
-    @beforeEach()
+    @BeforeEach()
     private beforeEach() {
         this.visitor = new TestRunnerVisitor();
     }
 
-    protected getTestSuiteInstance(testClass: any): TestSuite {
+    protected getTestSuiteInstance(testClass: any): TestSuiteInstance {
         return testClass.__testSuiteInstance;
     }
 }

--- a/src/spec/tests/testRunnerVisitor.spec.ts
+++ b/src/spec/tests/testRunnerVisitor.spec.ts
@@ -1,7 +1,7 @@
-import { testSuite, beforeEach, test, expect } from '../../testyCore';
+import { TestSuite, BeforeEach, Test, expect } from '../../testyCore';
 import { TestRunnerVisitor } from '../../lib/tests/visitors/testRunnerVisitor';
-import { TestSuite } from '../../lib/tests/testSuite';
-import { Test } from '../../lib/tests/test';
+import { TestSuiteInstance } from '../../lib/tests/testSuite';
+import { TestInstance } from '../../lib/tests/test';
 import { TestStatus } from '../../lib/testStatus';
 import { CompositeReport } from '../../lib/reporting/report/compositeReport';
 import { SuccessfulTestReport } from '../../lib/reporting/report/successfulTestReport';
@@ -11,23 +11,23 @@ import { Report } from '../../lib/reporting/report/report';
 import { LeafReport } from '../../lib/reporting/report/leafReport';
 
 
-@testSuite('Test Runner Visitor Tests')
+@TestSuite('Test Runner Visitor Tests')
 export class TestRunnerVisitorTests {
 
     private testRunnerVisitor: TestRunnerVisitor;
 
-    @beforeEach()
+    @BeforeEach()
     beforeEach() {
         this.testRunnerVisitor = new TestRunnerVisitor();
     }
 
-    @test('Simple test suite')
+    @Test('Simple test suite')
     async simpleTestSuite() {
         // Arrange
-        const testSuite = new TestSuite();
+        const testSuite = new TestSuiteInstance();
         testSuite.name = 'myTestSuite';
-        testSuite.set('testA', new Test('testA', () => { }, TestStatus.Normal));
-        testSuite.set('testB', new Test('testB', () => { }, TestStatus.Normal));
+        testSuite.set('testA', new TestInstance('testA', () => { }, TestStatus.Normal));
+        testSuite.set('testB', new TestInstance('testB', () => { }, TestStatus.Normal));
 
         const expectedReport = new CompositeReport('myTestSuite');
         expectedReport.addReport(new SuccessfulTestReport('testA', 0));
@@ -40,13 +40,13 @@ export class TestRunnerVisitorTests {
         this.expectReportsToBeEqual(actualReport, expectedReport);
     }
 
-    @test('Test suite with failure')
+    @Test('Test suite with failure')
     async testSuiteWithFailure() {
         // Arrange
-        const testSuite = new TestSuite();
+        const testSuite = new TestSuiteInstance();
         testSuite.name = 'myTestSuite';
-        testSuite.set('testA', new Test('testA', () => { }, TestStatus.Normal));
-        testSuite.set('testB', new Test('testB', () => { throw new Error('oops'); }, TestStatus.Normal));
+        testSuite.set('testA', new TestInstance('testA', () => { }, TestStatus.Normal));
+        testSuite.set('testB', new TestInstance('testB', () => { throw new Error('oops'); }, TestStatus.Normal));
 
         const expectedReport = new CompositeReport('myTestSuite');
         expectedReport.addReport(new SuccessfulTestReport('testA', 0));
@@ -59,13 +59,13 @@ export class TestRunnerVisitorTests {
         this.expectReportsToBeEqual(actualReport, expectedReport);
     }
 
-    @test('Test suite with skipped tests')
+    @Test('Test suite with skipped tests')
     async testSuiteWithSkippedTests() {
         // Arrange
-        const testSuite = new TestSuite();
+        const testSuite = new TestSuiteInstance();
         testSuite.name = 'myTestSuite';
-        testSuite.set('testA', new Test('testA', () => { }, TestStatus.Ignored));
-        testSuite.set('testB', new Test('testB', () => { }, TestStatus.Normal));
+        testSuite.set('testA', new TestInstance('testA', () => { }, TestStatus.Ignored));
+        testSuite.set('testB', new TestInstance('testB', () => { }, TestStatus.Normal));
 
         const expectedReport = new CompositeReport('myTestSuite');
         expectedReport.addReport(new SkippedTestReport('testA'));
@@ -78,18 +78,18 @@ export class TestRunnerVisitorTests {
         this.expectReportsToBeEqual(actualReport, expectedReport);
     }
 
-    @test('Test suite with focused tests')
+    @Test('Test suite with focused tests')
     async testSuiteWithFocusedTests() {
         // Arrange
-        const testSuite = new TestSuite();
+        const testSuite = new TestSuiteInstance();
         testSuite.name = 'myTestSuite';
-        testSuite.set('testA', new Test('testA', () => { }, TestStatus.Focused));
-        testSuite.set('testB', new Test('testB', () => { }, TestStatus.Normal));
+        testSuite.set('testA', new TestInstance('testA', () => { }, TestStatus.Focused));
+        testSuite.set('testB', new TestInstance('testB', () => { }, TestStatus.Normal));
 
-        const subTestSuite = new TestSuite();
+        const subTestSuite = new TestSuiteInstance();
         subTestSuite.name = 'subTestSuite';
-        subTestSuite.set('testC1', new Test('testC1', () => { }, TestStatus.Normal));
-        subTestSuite.set('testC2', new Test('testC2', () => { }, TestStatus.Normal));
+        subTestSuite.set('testC1', new TestInstance('testC1', () => { }, TestStatus.Normal));
+        subTestSuite.set('testC2', new TestInstance('testC2', () => { }, TestStatus.Normal));
 
         const expectedReport = new CompositeReport('myTestSuite');
         expectedReport.addReport(new SuccessfulTestReport('testA', 0));

--- a/src/spec/tests/testSuite.spec.ts
+++ b/src/spec/tests/testSuite.spec.ts
@@ -1,179 +1,179 @@
-import { testSuite, test, expect, ftest } from '../../testyCore';
-import { TestSuite } from '../../lib/tests/testSuite';
+import { TestSuite, Test, expect } from '../../testyCore';
+import { TestSuiteInstance } from '../../lib/tests/testSuite';
 import { TestStatus } from '../../lib/testStatus';
-import { Test } from '../../lib/tests/test';
+import { TestInstance } from '../../lib/tests/test';
 
-@testSuite('Tests Suite Tests')
+@TestSuite('Tests Suite Tests')
 export class TestSuiteTests {
 
-    @test('get tests, all normal tests')
+    @Test('get tests, all normal tests')
     getTestsAllNormalTests() {
         // Arrange
-        const testcases = new TestSuite();
+        const testcases = new TestSuiteInstance();
         testcases.context = { key: 'somedummycontext' };
         testcases.status = TestStatus.Normal;
-        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
-        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Normal));
-        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+        testcases.set('a.a', new TestInstance('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new TestInstance('a.b', undefined, TestStatus.Normal));
+        testcases.set('a.c', new TestInstance('a.c', undefined, TestStatus.Normal));
 
-        const testsuite = new TestSuite();
+        const testsuite = new TestSuiteInstance();
         testsuite.status = TestStatus.Normal;
         testsuite.set('a', testcases);
-        testsuite.set('b', new Test('b', undefined, TestStatus.Normal));
-        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+        testsuite.set('b', new TestInstance('b', undefined, TestStatus.Normal));
+        testsuite.set('c', new TestInstance('c', undefined, TestStatus.Normal));
 
         // Act & Assert
-        const actualTestcases = testsuite.get('a') as TestSuite;
+        const actualTestcases = testsuite.get('a') as TestSuiteInstance;
         expect.toBeDefined(actualTestcases.context);
         expect.toBeEqual(actualTestcases.context.key, 'somedummycontext');
-        expect.toBeEqual((actualTestcases.get('a.a') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((actualTestcases.get('a.b') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((actualTestcases.get('a.c') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((testsuite.get('b') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((testsuite.get('c') as Test).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.a') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.b') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.c') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((testsuite.get('b') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((testsuite.get('c') as TestInstance).status, TestStatus.Normal);
     }
 
-    @test('get tests, has top level focused test')
+    @Test('get tests, has top level focused test')
     getTestsTopLevelFocusedTest() {
         // Arrange
-        const testcases = new TestSuite();
+        const testcases = new TestSuiteInstance();
         testcases.context = { key: 'somedummycontext' };
-        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
-        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Normal));
-        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+        testcases.set('a.a', new TestInstance('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new TestInstance('a.b', undefined, TestStatus.Normal));
+        testcases.set('a.c', new TestInstance('a.c', undefined, TestStatus.Normal));
 
-        const testsuite = new TestSuite();
+        const testsuite = new TestSuiteInstance();
         testsuite.set('a', testcases);
-        testsuite.set('b', new Test('b', undefined, TestStatus.Focused));
-        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+        testsuite.set('b', new TestInstance('b', undefined, TestStatus.Focused));
+        testsuite.set('c', new TestInstance('c', undefined, TestStatus.Normal));
 
         // Act & Assert
-        const actualTestcases = testsuite.get('a') as TestSuite;
+        const actualTestcases = testsuite.get('a') as TestSuiteInstance;
         expect.toBeDefined(actualTestcases.context);
         expect.toBeEqual(actualTestcases.context.key, 'somedummycontext');
-        expect.toBeEqual((actualTestcases.get('a.a') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((actualTestcases.get('a.b') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((actualTestcases.get('a.c') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((testsuite.get('b') as Test).status, TestStatus.Focused);
-        expect.toBeEqual((testsuite.get('c') as Test).status, TestStatus.Ignored);
+        expect.toBeEqual((actualTestcases.get('a.a') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((actualTestcases.get('a.b') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((actualTestcases.get('a.c') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((testsuite.get('b') as TestInstance).status, TestStatus.Focused);
+        expect.toBeEqual((testsuite.get('c') as TestInstance).status, TestStatus.Ignored);
     }
 
-    @test('get tests, has nested focused tests')
+    @Test('get tests, has nested focused tests')
     getTestsNestedFocusedTests() {
         // Arrange
-        const testcases = new TestSuite();
+        const testcases = new TestSuiteInstance();
         testcases.context = { key: 'somedummycontext' };
-        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
-        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Focused));
-        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+        testcases.set('a.a', new TestInstance('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new TestInstance('a.b', undefined, TestStatus.Focused));
+        testcases.set('a.c', new TestInstance('a.c', undefined, TestStatus.Normal));
 
-        const testsuite = new TestSuite();
+        const testsuite = new TestSuiteInstance();
         testsuite.set('a', testcases);
-        testsuite.set('b', new Test('b', undefined, TestStatus.Normal));
-        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+        testsuite.set('b', new TestInstance('b', undefined, TestStatus.Normal));
+        testsuite.set('c', new TestInstance('c', undefined, TestStatus.Normal));
 
         // Act & Assert
-        const actualTestcases = testsuite.get('a') as TestSuite;
+        const actualTestcases = testsuite.get('a') as TestSuiteInstance;
         expect.toBeDefined(actualTestcases.context);
         expect.toBeEqual(actualTestcases.context.key, 'somedummycontext');
-        expect.toBeEqual((actualTestcases.get('a.a') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((actualTestcases.get('a.b') as Test).status, TestStatus.Focused);
-        expect.toBeEqual((actualTestcases.get('a.c') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((testsuite.get('b') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((testsuite.get('c') as Test).status, TestStatus.Ignored);
+        expect.toBeEqual((actualTestcases.get('a.a') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((actualTestcases.get('a.b') as TestInstance).status, TestStatus.Focused);
+        expect.toBeEqual((actualTestcases.get('a.c') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((testsuite.get('b') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((testsuite.get('c') as TestInstance).status, TestStatus.Ignored);
     }
 
-    @test('get tests, has nested focused test suite')
+    @Test('get tests, has nested focused test suite')
     getTestsNestedFocusedTestSuite() {
         // Arrange
-        const testcases = new TestSuite();
+        const testcases = new TestSuiteInstance();
         testcases.context = { key: 'somedummycontext' };
         testcases.status = TestStatus.Focused;
-        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
-        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Normal));
-        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+        testcases.set('a.a', new TestInstance('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new TestInstance('a.b', undefined, TestStatus.Normal));
+        testcases.set('a.c', new TestInstance('a.c', undefined, TestStatus.Normal));
 
-        const testsuite = new TestSuite();
+        const testsuite = new TestSuiteInstance();
         testsuite.set('a', testcases);
-        testsuite.set('b', new Test('b', undefined, TestStatus.Normal));
-        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+        testsuite.set('b', new TestInstance('b', undefined, TestStatus.Normal));
+        testsuite.set('c', new TestInstance('c', undefined, TestStatus.Normal));
 
         // Act & Assert
-        const actualTestcases = testsuite.get('a') as TestSuite;
+        const actualTestcases = testsuite.get('a') as TestSuiteInstance;
         expect.toBeDefined(actualTestcases.context);
         expect.toBeEqual(actualTestcases.context.key, 'somedummycontext');
-        expect.toBeEqual((actualTestcases.get('a.a') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((actualTestcases.get('a.b') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((actualTestcases.get('a.c') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((testsuite.get('b') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((testsuite.get('c') as Test).status, TestStatus.Ignored);
+        expect.toBeEqual((actualTestcases.get('a.a') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.b') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.c') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((testsuite.get('b') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((testsuite.get('c') as TestInstance).status, TestStatus.Ignored);
     }
 
-    @test('get tests, is a focused test suite')
+    @Test('get tests, is a focused test suite')
     getTestsIsAFocusedTestSuite() {
         // Arrange
-        const testcases = new TestSuite();
+        const testcases = new TestSuiteInstance();
         testcases.status = TestStatus.Normal;
         testcases.context = { key: 'somedummycontext' };
-        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
-        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Normal));
-        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+        testcases.set('a.a', new TestInstance('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new TestInstance('a.b', undefined, TestStatus.Normal));
+        testcases.set('a.c', new TestInstance('a.c', undefined, TestStatus.Normal));
 
-        const testsuite = new TestSuite();
+        const testsuite = new TestSuiteInstance();
         testsuite.status = TestStatus.Focused;
         testsuite.set('a', testcases);
-        testsuite.set('b', new Test('b', undefined, TestStatus.Normal));
-        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+        testsuite.set('b', new TestInstance('b', undefined, TestStatus.Normal));
+        testsuite.set('c', new TestInstance('c', undefined, TestStatus.Normal));
 
         // Act & Assert
-        const actualTestcases = testsuite.get('a') as TestSuite;
+        const actualTestcases = testsuite.get('a') as TestSuiteInstance;
         expect.toBeDefined(actualTestcases.context);
         expect.toBeEqual(actualTestcases.context.key, 'somedummycontext');
-        expect.toBeEqual((actualTestcases.get('a.a') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((actualTestcases.get('a.b') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((actualTestcases.get('a.c') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((testsuite.get('b') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((testsuite.get('c') as Test).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.a') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.b') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.c') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((testsuite.get('b') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((testsuite.get('c') as TestInstance).status, TestStatus.Normal);
     }
 
-    @test('get tests, has ignored tests')
+    @Test('get tests, has ignored tests')
     getTestsIgnoredTests() {
         // Arrange
-        const testcases = new TestSuite();
+        const testcases = new TestSuiteInstance();
         testcases.context = { key: 'somedummycontext' };
-        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
-        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Ignored));
-        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+        testcases.set('a.a', new TestInstance('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new TestInstance('a.b', undefined, TestStatus.Ignored));
+        testcases.set('a.c', new TestInstance('a.c', undefined, TestStatus.Normal));
 
-        const testsuite = new TestSuite();
+        const testsuite = new TestSuiteInstance();
         testsuite.set('a', testcases);
-        testsuite.set('b', new Test('b', undefined, TestStatus.Ignored));
-        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+        testsuite.set('b', new TestInstance('b', undefined, TestStatus.Ignored));
+        testsuite.set('c', new TestInstance('c', undefined, TestStatus.Normal));
 
         // Act & Assert
-        const actualTestcases = testsuite.get('a') as TestSuite;
+        const actualTestcases = testsuite.get('a') as TestSuiteInstance;
         expect.toBeDefined(actualTestcases.context);
         expect.toBeEqual(actualTestcases.context.key, 'somedummycontext');
-        expect.toBeEqual((actualTestcases.get('a.a') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((actualTestcases.get('a.b') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((actualTestcases.get('a.c') as Test).status, TestStatus.Normal);
-        expect.toBeEqual((testsuite.get('b') as Test).status, TestStatus.Ignored);
-        expect.toBeEqual((testsuite.get('c') as Test).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.a') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((actualTestcases.get('a.b') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((actualTestcases.get('a.c') as TestInstance).status, TestStatus.Normal);
+        expect.toBeEqual((testsuite.get('b') as TestInstance).status, TestStatus.Ignored);
+        expect.toBeEqual((testsuite.get('c') as TestInstance).status, TestStatus.Normal);
     }
 
-    @test('clone')
+    @Test('clone')
     clone() {
         // Arrange
-        const testcases = new TestSuite();
+        const testcases = new TestSuiteInstance();
         testcases.context = { key: 'somedummycontext' };
-        testcases.set('a.a', new Test('a.a', undefined, TestStatus.Normal));
-        testcases.set('a.b', new Test('a.b', undefined, TestStatus.Ignored));
-        testcases.set('a.c', new Test('a.c', undefined, TestStatus.Normal));
+        testcases.set('a.a', new TestInstance('a.a', undefined, TestStatus.Normal));
+        testcases.set('a.b', new TestInstance('a.b', undefined, TestStatus.Ignored));
+        testcases.set('a.c', new TestInstance('a.c', undefined, TestStatus.Normal));
 
-        const testsuite = new TestSuite();
+        const testsuite = new TestSuiteInstance();
         testsuite.set('a', testcases);
-        testsuite.set('b', new Test('b', undefined, TestStatus.Ignored));
-        testsuite.set('c', new Test('c', undefined, TestStatus.Normal));
+        testsuite.set('b', new TestInstance('b', undefined, TestStatus.Ignored));
+        testsuite.set('c', new TestInstance('c', undefined, TestStatus.Normal));
 
         // Act
         const clone = testcases.clone();

--- a/src/spec/tests/visitors/focusedTest.ts
+++ b/src/spec/tests/visitors/focusedTest.ts
@@ -1,18 +1,18 @@
-import { test, ftest } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test, FTest } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Focused Test Test Suite')
+@TestSuite('Focused Test Test Suite')
 export class FocusedTestTestSuite {
 
     public numberOfRunsTest1: number = 0;
     public numberOfRunsTest2: number = 0;
 
-    @ftest('My first test')
+    @FTest('My first test')
     private test1() {
         ++this.numberOfRunsTest1;
     }
 
-    @test('My second test')
+    @Test('My second test')
     private test2() {
         ++this.numberOfRunsTest2;
     }

--- a/src/spec/tests/visitors/multipleTests.ts
+++ b/src/spec/tests/visitors/multipleTests.ts
@@ -1,24 +1,24 @@
-import { test } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Multiple Test Test Suite')
+@TestSuite('Multiple Test Test Suite')
 export class MultipleTestsTestSuite {
 
     public numberOfRunsTest1: number = 0;
     public numberOfRunsTest2: number = 0;
     public numberOfRunsTest3: number = 0;
 
-    @test('My first test')
+    @Test('My first test')
     private test1() {
         ++this.numberOfRunsTest1;
     }
 
-    @test('My second test')
+    @Test('My second test')
     private test2() {
         ++this.numberOfRunsTest2;
     }
 
-    @test('My third test')
+    @Test('My third test')
     private test3() {
         ++this.numberOfRunsTest3;
     }

--- a/src/spec/tests/visitors/timeoutTestDecoratorTestSuite.ts
+++ b/src/spec/tests/visitors/timeoutTestDecoratorTestSuite.ts
@@ -1,9 +1,9 @@
-import { test } from '../../../testyCore';
-import { testSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Test } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 
-@testSuite('Timeout Test Decorator Test Suite')
+@TestSuite('Timeout Test Decorator Test Suite')
 export class TimeoutTestDecoratorTestSuite {
-    @test('My test with test cases', undefined, 10)
+    @Test('My test with test cases', undefined, 10)
     private async tests(n: number) {
         await new Promise(resolve => setTimeout(() => resolve(), 1000));
     }

--- a/src/testyCore.ts
+++ b/src/testyCore.ts
@@ -1,6 +1,10 @@
-export { test, ftest, xtest } from './lib/decorators/test.decorator';
-export { testSuite, ftestSuite, xtestSuite } from './lib/decorators/testSuite.decorator';
+export { Test, FTest, XTest } from './lib/decorators/test.decorator';
+export { TestSuite, FTestSuite, XTestSuite } from './lib/decorators/testSuite.decorator';
 export { expect } from './lib/assertion/expect';
 export { TestCase } from './lib/testCase';
-export { afterAll, afterEach, beforeEach, beforeAll } from './lib/decorators/afterAndBefore.decorator';
+export { AfterAll, AfterEach, BeforeEach, BeforeAll } from './lib/decorators/afterAndBefore.decorator';
 export { TestResult } from './lib/reporting/report/testResult';
+
+export { afterAll, afterEach, beforeEach, beforeAll } from './lib/decorators/afterAndBefore.decorator';
+// export { test, ftest, xtest } from './lib/decorators/test.decorator';
+// export { testSuite, ftestSuite, xtestSuite } from './lib/decorators/testSuite.decorator';


### PR DESCRIPTION
## Purpose
It's been brought to my attention that my decorators did not follow the same naming convention as the most popular libraries. The purpose of this PR is to fix this. The previous names will still be available for a while, though they will appear as deprecated.

## Approach
Ctrl+F and Ctrl+R+R the hell out of the code.
