### PR TITLE
Feature/26 timeout decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export class MyTestSuite {
 
 ### Timeout
 
-If a test is taking too long to complete, it will fail automatically. The default timeout it 2000 ms, but you can configure it.
+If a test is taking too long to complete, it will fail automatically. The default timeout it 2000 ms, but you can configure it. Please note that the `Timeout` decorator goes after the `Test` decorator.
 
 ```ts
 @TestSuite()

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ If a test is taking too long to complete, it will fail automatically. The defaul
 ```ts
 @TestSuite()
 export class MyTestSuite {
-    @Test(undefined, undefined) 
+    @Test() 
     @Timeout(100000) // Really slow test
     slowTest() {
        // Some test

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ If a test is taking too long to complete, it will fail automatically. The defaul
 ```ts
 @TestSuite()
 export class MyTestSuite {
-    @Test(undefined, undefined, 10000) // Really slow test
+    @Test(undefined, undefined) 
+    @Timeout(100000) // Really slow test
     slowTest() {
        // Some test
     }

--- a/src/lib/decorators/test.decorator.ts
+++ b/src/lib/decorators/test.decorator.ts
@@ -8,10 +8,9 @@ import { TestSuiteInstance } from '../tests/testSuite';
  *
  * @param name Name of the test, displayed in the test report.
  * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
- * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
-export function Test(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return generateDecoratorFunction(name, TestStatus.Normal, testCases, timeout);
+export function Test(name?: string, testCases?: TestCase[]) {
+    return generateDecoratorFunction(name, TestStatus.Normal, testCases);
 }
 
 /**
@@ -20,10 +19,9 @@ export function Test(name?: string, testCases?: TestCase[], timeout: number = 20
  *
  * @param name Name of the test, displayed in the test report.
  * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
- * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
-export function FTest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return generateDecoratorFunction(name, TestStatus.Focused, testCases, timeout);
+export function FTest(name?: string, testCases?: TestCase[]) {
+    return generateDecoratorFunction(name, TestStatus.Focused, testCases);
 }
 
 /** 
@@ -32,10 +30,9 @@ export function FTest(name?: string, testCases?: TestCase[], timeout: number = 2
  * 
  * @param name Name of the test, displayed in the test report.
  * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
- * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
-export function XTest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return generateDecoratorFunction(name, TestStatus.Ignored, testCases, timeout);
+export function XTest(name?: string, testCases?: TestCase[]) {
+    return generateDecoratorFunction(name, TestStatus.Ignored, testCases);
 }
 
 /**
@@ -44,10 +41,9 @@ export function XTest(name?: string, testCases?: TestCase[], timeout: number = 2
  *
  * @param name Name of the test, displayed in the test report.
  * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
- * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
-export function test(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return Test(name, testCases, timeout);
+export function test(name?: string, testCases?: TestCase[]) {
+    return Test(name, testCases);
 }
 
 /**
@@ -57,10 +53,9 @@ export function test(name?: string, testCases?: TestCase[], timeout: number = 20
  *
  * @param name Name of the test, displayed in the test report.
  * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
- * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
-export function ftest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return FTest(name, testCases, timeout);
+export function ftest(name?: string, testCases?: TestCase[]) {
+    return FTest(name, testCases);
 }
 
 /** 
@@ -70,10 +65,9 @@ export function ftest(name?: string, testCases?: TestCase[], timeout: number = 2
  * 
  * @param name Name of the test, displayed in the test report.
  * @param testCases Allows to run the test multiple times with different arguments. Arguments will be passed to the test class.
- * @param timeout The test will automaticlaly fail if it has been running for longer than the specified timeout.
  */
-export function xtest(name?: string, testCases?: TestCase[], timeout: number = 2000) {
-    return XTest(name, testCases, timeout);
+export function xtest(name?: string, testCases?: TestCase[]) {
+    return XTest(name, testCases);
 }
 
 function initializeTarget(target: any) {
@@ -85,8 +79,9 @@ function initializeTarget(target: any) {
     }
 }
 
-function generateDecoratorFunction(name: string, status: TestStatus, testCases: TestCase[], timeout: number) {
+function generateDecoratorFunction(name: string, status: TestStatus, testCases: TestCase[]) {
     return (target, key, descriptor) => {
+        const timeout = target.timeout === undefined ? 2000 : target.timeout;
         initializeTarget(target);
         const testSuiteInstance: TestSuiteInstance = target.__testSuiteInstance;
 

--- a/src/lib/decorators/timeout.decorator.ts
+++ b/src/lib/decorators/timeout.decorator.ts
@@ -1,0 +1,5 @@
+export function Timeout(timeout: number = 2000) {
+    return (target, key, descriptor) => {
+        target.timeout = timeout;
+    };
+}

--- a/src/lib/decorators/timeout.decorator.ts
+++ b/src/lib/decorators/timeout.decorator.ts
@@ -1,3 +1,7 @@
+/**
+ * Specifies the timeout to cause a test to fail.
+ * @param timeout The timeout in miliseconds.
+ */
 export function Timeout(timeout: number = 2000) {
     return (target, key, descriptor) => {
         target.timeout = timeout;

--- a/src/spec/decorators/timeoutDecorator/testSuiteWithTimeouts.ts
+++ b/src/spec/decorators/timeoutDecorator/testSuiteWithTimeouts.ts
@@ -1,0 +1,21 @@
+import { Test } from '../../../testyCore';
+import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
+import { Timeout } from '../../../lib/decorators/timeout.decorator';
+
+@TestSuite()
+export class TestSuiteWithTimeouts {
+
+    @Test()
+    @Timeout(0)
+    private async test1() {
+        return Promise.resolve();
+    }
+
+    @Test()
+    @Timeout(0)
+    private async test2() {
+        return new Promise(res => {
+            setTimeout(() => res(), 100);
+        });
+    }
+}

--- a/src/spec/decorators/timeoutDecorator/timeoutDecorator.spec.ts
+++ b/src/spec/decorators/timeoutDecorator/timeoutDecorator.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestSuite, expect, BeforeEach } from '../../../testyCore';
+import { TestUtils } from '../../utils/testUtils';
+import { TestSuiteWithTimeouts } from './testSuiteWithTimeouts';
+import { TestRunnerVisitor } from '../../../lib/tests/visitors/testRunnerVisitor';
+import { CompositeReport } from '../../../lib/reporting/report/compositeReport';
+import { FailedTestReport } from '../../../lib/reporting/report/failedTestReport';
+import { SuccessfulTestReport } from '../../../lib/reporting/report/successfulTestReport';
+
+@TestSuite('Test suite with timeouts')
+export class TestDecoratorTestSuite {
+
+    private testRunnerVisitor: TestRunnerVisitor;
+
+    @BeforeEach()
+    beforeEach() {
+        this.testRunnerVisitor = new TestRunnerVisitor();
+    }
+
+    @Test('One successful test, one timeout')
+    private async singleTest() {
+        // Arrange
+        const testSuite = TestUtils.getInstance(TestSuiteWithTimeouts);
+
+        // Act
+        const report = await testSuite.accept(this.testRunnerVisitor) as CompositeReport;
+        const successfulTest = report.getChildren()[0] ;
+        const failedTest = report.getChildren()[1];
+
+        // Assert
+        expect.toBeEqual(report.numberOfSuccessfulTests, 1);
+        expect.toBeTrue(successfulTest instanceof SuccessfulTestReport);
+        expect.toBeTrue(failedTest instanceof FailedTestReport);
+        expect.toBeEqual((failedTest as FailedTestReport).message, 'Test has timed out.');
+    }
+}

--- a/src/spec/tests/visitors/asyncTestsFailures.ts
+++ b/src/spec/tests/visitors/asyncTestsFailures.ts
@@ -1,10 +1,12 @@
 import { TestSuite } from '../../../lib/decorators/testSuite.decorator';
 import { Test } from '../../../testyCore';
+import { Timeout } from '../../../lib/decorators/timeout.decorator';
 
 @TestSuite()
 export class AsyncTestsFailures {
 
-    @Test(undefined, undefined, 0)
+    @Test(undefined, undefined)
+    @Timeout(0)
     async testA() {
         await new Promise(() => { });
     }


### PR DESCRIPTION
## Purpose
This PR implements the `@Timeout` decorator. It removes the `timeout` argument from the `@Test` decorator.

## Approach
Added a `timeout` attribute to the target function. This value is used by the `@Test` decorator.