### PR TITLE
Testy config ts config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,28 @@ export class MyTestSuite {
 }
 ```
 
+## Configuration file
+
+```json
+{
+    "tsconfig": "path/to/your/tsconfig.json",
+    "include": [
+        "src/**/*.spec.ts"
+    ]
+}
+```
+
+## Cli arguments
+
+Cli arguments will override config file values.
+
+
+```
+-c --config <config> // Specify a testy.json configuration file
+-t --tsconfig <tsconfig> // Specify a tsconfig.json file
+-r --reporter <reporter> // Specify a reporter. Either standard or TAP.
+```
+
 ## Run the tests
 
 To run the tests, use the following command

--- a/src/lib/cli/run.command.ts
+++ b/src/lib/cli/run.command.ts
@@ -15,12 +15,25 @@ export class RunCommand implements CliCommand {
     constructor(private logger: Logger,
         private testRunnerVisitor: TestVisitor<Report>,
         private _testyConfigFile: string = 'testy.json',
-        private _tsConfigFile = 'tsconfig.json') {
+        private _tsConfigFile) {
     }
 
     public async execute() {
         const testyConfig = await this.loadTestyConfig();
-        const tsConfig = await this.loadTsConfig();
+        // We load the tsConfig file. In priority order, we use
+        // 1. The tsconfig file specified from the command line
+        // 2. The tsconfig file specified in the testy config file
+        // 3. The root folder's tsconfig.json file
+        let tsConfigPath = this.tsConfigFile;
+        if (tsConfigPath == null) {
+            tsConfigPath = testyConfig.tsconfig;
+        }
+        
+        if (tsConfigPath == null) {
+            tsConfigPath = 'tsconfig.json';
+        }
+
+        const tsConfig = await this.loadTsConfig(tsConfigPath);
 
         const testsLoader = new TestsLoader(this.logger);
         const testSuites = await testsLoader.loadTests(process.cwd(), testyConfig.include, tsConfig);
@@ -32,8 +45,8 @@ export class RunCommand implements CliCommand {
         return await this.loadConfig<TestyConfig>(this._testyConfigFile);
     }
 
-    private async loadTsConfig(): Promise<tsnode.Options> {
-        return await this.loadConfig<tsnode.Options>(this._tsConfigFile);
+    private async loadTsConfig(tsConfigPath: string): Promise<tsnode.Options> {
+        return await this.loadConfig<tsnode.Options>(tsConfigPath);
     }
 
     private async loadConfig<T>(file: string): Promise<T> {

--- a/src/lib/cli/testyCli.ts
+++ b/src/lib/cli/testyCli.ts
@@ -16,7 +16,8 @@ export class TestyCli {
             await command.execute();
         }
         catch (err) {
-            this.logger.error(`An error occured while executing the following command: ${command}. Error: "${err.message}"`);
+            const commandStr = args.join(' ');
+            this.logger.error(`An error occured while executing the following command: ${commandStr}. Error: "${err.message}"`);
         }
     }
 
@@ -32,7 +33,7 @@ export class TestyCli {
 
             program
                 .option('-c --config <config>', 'Specify a config file.', './testy.json')
-                .option('-t --tsconfig <tsconfig>', 'Specify a tsconfig config file.', './tsconfig.json')
+                .option('-t --tsconfig <tsconfig>', 'Specify a tsconfig config file.', undefined)
                 .option('-r --reporter <reporter>', 'Specifies the reporter type', /(standard|TAP)/, 'standard')
 
             program.parse(args);

--- a/src/lib/interfaces/config.ts
+++ b/src/lib/interfaces/config.ts
@@ -1,3 +1,4 @@
 export interface TestyConfig {
+    tsconfig?: string;
     include: string[];
 }

--- a/src/spec/cli/cli.spec.ts
+++ b/src/spec/cli/cli.spec.ts
@@ -32,23 +32,24 @@ export class CliTests {
     }
 
     @Test('Run command')
-    @TestCase('testy', ['node', '/some/path'], './testy.json', './tsconfig.json')
-    @TestCase('testy -c alternate/config.json', ['node', '/some/path', '-c', 'alternate/config.json'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy --config alternate/config.json', ['node', '/some/path', '--config', 'alternate/config.json'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy -r TAP', ['node', '/some/path', '-r', 'TAP'], './testy.json', './tsconfig.json')
-    @TestCase('testy --reporter TAP', ['node', '/some/path', '--reporter', 'TAP'], './testy.json', './tsconfig.json')
-    @TestCase('testy -r standard', ['node', '/some/path', '-r', 'standard'], './testy.json', './tsconfig.json')
-    @TestCase('testy --reporter standard', ['node', '/some/path', '--reporter', 'standard'], './testy.json', './tsconfig.json')
+    @TestCase('testy', ['node', '/some/path'], './testy.json')
+    @TestCase('testy --tsconfig some/tsconfig.json', ['node', '/some/path', '--tsconfig', 'some/tsconfig.json'], './testy.json', 'some/tsconfig.json')
+    @TestCase('testy -c alternate/config.json', ['node', '/some/path', '-c', 'alternate/config.json'], 'alternate/config.json')
+    @TestCase('testy --config alternate/config.json', ['node', '/some/path', '--config', 'alternate/config.json'], 'alternate/config.json')
+    @TestCase('testy -r TAP', ['node', '/some/path', '-r', 'TAP'], './testy.json')
+    @TestCase('testy --reporter TAP', ['node', '/some/path', '--reporter', 'TAP'], './testy.json')
+    @TestCase('testy -r standard', ['node', '/some/path', '-r', 'standard'], './testy.json')
+    @TestCase('testy --reporter standard', ['node', '/some/path', '--reporter', 'standard'], './testy.json')
     @TestCase('testy -c some/testy.json -t some/path/tsconfig.json', ['node', '--config', 'some/testy.json', '-t', 'some/path/tsconfig.json'], 'some/testy.json', 'some/path/tsconfig.json')
-    @TestCase('testy -r TAP --config alternate/config.json', ['node', '/some/path', '-r', 'TAP', '--config', 'alternate/config.json'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy --reporter TAP --config alternate/config.json', ['node', '/some/path', '--reporter', 'TAP', '--config', 'alternate/config.json'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy --config alternate/config.json -r TAP', ['node', '/some/path', '--config', 'alternate/config.json', '-r', 'TAP'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy --config alternate/config.json --reporter TAP', ['node', '/some/path', '--config', 'alternate/config.json', '--reporter', 'TAP'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy -r standard --config alternate/config.json', ['node', '/some/path', '-r', 'standard', '--config', 'alternate/config.json'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy --reporter standard --config alternate/config.json', ['node', '/some/path', '--reporter', 'standard', '--config', 'alternate/config.json'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy --config alternate/config.json -r standard', ['node', '/some/path', '--config', 'alternate/config.json', '-r', 'standard'], 'alternate/config.json', './tsconfig.json')
-    @TestCase('testy --config alternate/config.json --reporter standard', ['node', '/some/path', '--config', 'alternate/config.json', '--reporter', 'standard'], 'alternate/config.json', './tsconfig.json')
-    private async runCommandTests(args: any[], expectedConfig: string, expectedTsConfig: string) {
+    @TestCase('testy -r TAP --config alternate/config.json', ['node', '/some/path', '-r', 'TAP', '--config', 'alternate/config.json'], 'alternate/config.json')
+    @TestCase('testy --reporter TAP --config alternate/config.json', ['node', '/some/path', '--reporter', 'TAP', '--config', 'alternate/config.json'], 'alternate/config.json')
+    @TestCase('testy --config alternate/config.json -r TAP', ['node', '/some/path', '--config', 'alternate/config.json', '-r', 'TAP'], 'alternate/config.json')
+    @TestCase('testy --config alternate/config.json --reporter TAP', ['node', '/some/path', '--config', 'alternate/config.json', '--reporter', 'TAP'], 'alternate/config.json')
+    @TestCase('testy -r standard --config alternate/config.json', ['node', '/some/path', '-r', 'standard', '--config', 'alternate/config.json'], 'alternate/config.json')
+    @TestCase('testy --reporter standard --config alternate/config.json', ['node', '/some/path', '--reporter', 'standard', '--config', 'alternate/config.json'], 'alternate/config.json')
+    @TestCase('testy --config alternate/config.json -r standard', ['node', '/some/path', '--config', 'alternate/config.json', '-r', 'standard'], 'alternate/config.json')
+    @TestCase('testy --config alternate/config.json --reporter standard', ['node', '/some/path', '--config', 'alternate/config.json', '--reporter', 'standard'], 'alternate/config.json')
+    private async runCommandTests(args: any[], expectedConfig: string, expectedTsConfig: string = undefined) {
         // Act
         const command = await this.cli.getCommand(args);
 


### PR DESCRIPTION
## Purpose
Add support for specifying a tsconfig.json file in the testy.json configuration file.

## Approach
Added the config. Didn't add tests because it would be kind of hard to test.
