### PR TITLE
set error code on exceptions

### DIFF
--- a/src/lib/cli/testyCli.ts
+++ b/src/lib/cli/testyCli.ts
@@ -16,6 +16,7 @@ export class TestyCli {
         catch (err) {
             const commandStr = args.join(' ');
             this.logger.error(`An error occured while executing the following command: ${commandStr}. Error: "${err.message}"`);
+            process.exitCode = 1;
         }
     }
 


### PR DESCRIPTION
Tools like npm wouldn't register errors if there was a fatal error (like compilation crash)