### PR TITLE
Bugfix/41 tsconfig comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,9 +161,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.12.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
-            "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
+            "version": "10.17.21",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+            "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ==",
             "dev": true
         },
         "agent-base": {
@@ -174,18 +174,6 @@
             "requires": {
                 "debug": "4"
             }
-        },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
-        },
-        "ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
         },
         "append-transform": {
             "version": "1.0.0",
@@ -221,32 +209,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-        },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                }
-            }
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -379,9 +341,9 @@
             "dev": true
         },
         "commander": {
-            "version": "4.0.0-1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.0-1.tgz",
-            "integrity": "sha512-6UCnFDyJnZfk4ZugvEhl8hYtlViGJNVki5J+3x/zNd8nLDpBcDHZShvBYWKIIktsiBUuRDttP/qG1yF+bhhVnQ=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
         },
         "commondir": {
             "version": "1.0.1",
@@ -536,9 +498,9 @@
             "dev": true
         },
         "glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -559,15 +521,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
             "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
             "dev": true
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
         },
         "has-flag": {
             "version": "3.0.0",
@@ -650,9 +603,9 @@
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -759,12 +712,6 @@
             "requires": {
                 "html-escaper": "^2.0.0"
             }
-        },
-        "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-            "dev": true
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -1261,15 +1208,6 @@
                 }
             }
         },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
         "strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -1280,12 +1218,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
             "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
-            "dev": true
-        },
-        "supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
         "teeny-request": {
@@ -1335,35 +1267,42 @@
             }
         },
         "tslib": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+            "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
             "dev": true
         },
         "tslint": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
-            "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
+            "version": "5.20.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+            "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
+                "@babel/code-frame": "^7.0.0",
                 "builtin-modules": "^1.1.1",
                 "chalk": "^2.3.0",
                 "commander": "^2.12.1",
-                "diff": "^3.2.0",
+                "diff": "^4.0.1",
                 "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
+                "js-yaml": "^3.13.1",
                 "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
                 "resolve": "^1.3.2",
                 "semver": "^5.3.0",
                 "tslib": "^1.8.0",
-                "tsutils": "^2.27.2"
+                "tsutils": "^2.29.0"
             },
             "dependencies": {
                 "commander": {
                     "version": "2.20.3",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
                     "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                },
+                "diff": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
                     "dev": true
                 }
             }
@@ -1378,9 +1317,9 @@
             }
         },
         "typescript": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
-            "integrity": "sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA=="
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
         },
         "urlgrey": {
             "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -31,18 +31,18 @@
     "homepage": "https://github.com/Aboisier/testyts#readme",
     "dependencies": {
         "@testy/assertion": "^0.1.1",
-        "commander": "^4.0.0-1",
-        "glob": "^7.1.3",
+        "commander": "^4.1.1",
+        "glob": "^7.1.6",
         "reflect-metadata": "^0.1.12",
         "ts-node": "^7.0.1",
-        "typescript": "^3.1.6"
+        "typescript": "^3.8.3"
     },
     "devDependencies": {
         "@types/glob": "^7.1.1",
-        "@types/node": "^10.12.2",
+        "@types/node": "^10.17.21",
         "codecov": "^3.6.0",
         "nyc": "^14.1.1",
-        "tslint": "^5.11.0"
+        "tslint": "^5.20.1"
     },
     "nyc": {
         "include": [

--- a/src/lib/cli/run.command.ts
+++ b/src/lib/cli/run.command.ts
@@ -1,12 +1,13 @@
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import * as tsnode from 'ts-node';
+import { readConfigFile } from 'typescript';
 import { TestyConfig } from '../interfaces/config';
 import { Logger } from '../logger/logger';
+import { Report } from '../reporting/report/report';
+import { TestVisitor } from '../tests/visitors/testVisitor';
 import { TestsLoader } from '../utils/testsLoader';
 import { CliCommand } from './cliCommand';
-import { TestVisitor } from '../tests/visitors/testVisitor';
-import { Report } from '../reporting/report/report';
-import * as tsnode from 'ts-node';
 
 export class RunCommand implements CliCommand {
     public get testyConfigFile(): string { return this._testyConfigFile; }
@@ -54,6 +55,15 @@ export class RunCommand implements CliCommand {
         if (!existsSync(path))
             throw new Error(`The specified configuration file could not be found: ${path}`);
 
-        return await import(path);
+        const config = readConfigFile(path, this.readFile);
+        if (config?.error != null) {
+            throw new Error(`An error occured while reading the configuration file ${path}`);
+        }
+
+        return config.config;
+    }
+
+    private readFile(path: string): string {
+        return readFileSync(path).toString();
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+    // KEEP THIS COMMENT: This will detect regressions vis-à-vis issue #41
     "compilerOptions": {
         "module": "commonjs",
         "lib": [


### PR DESCRIPTION
## Purpose
This fixes #41 .

## Approach
I used TypeScript's `readConfigFile` method instead of importing config files. Comments are now also allowed in _testy.json_ config, although your IDE will probably complain. 