### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ export class MyTestSuite {
 ## Configuration file
 
 | Key        | Description                                                                                                                                                          | Type                        | Note       |
-| ---------- | -------------------------------ran------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ---------- |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ---------- |
 | `include`  | The [test loader](src\lib\utils\testsLoader.ts) will look for tests in files that match any of those [glob patterns](https://www.npmjs.com/package/glob#glob-primer) | `string[]`                  | _Required_ |
 | `tsconfig` | Alternate tsconfig for the test loader to use. If not specified, the loader will use the `tsconfig.json` in the current directory                                    | `string`                    | _Optional_ |
 | `timeout`  | Global test timeout. By default, the global timeout is 2000 ms. The global timeout will be overriden by test-level timeouts.                                         | `number`                    | _Optional_ |


### PR DESCRIPTION
## Purpose

The table in the Configuration file section was broken, because of a typo.

## Approach

It is pretty straight forward, lol.

## Learnings

Two pairs of eyes are always better than one.