### PR TITLE
Made array arguments `readonly`.

### DIFF
--- a/src/lib/assertion/expect.ts
+++ b/src/lib/assertion/expect.ts
@@ -43,7 +43,7 @@ class Expect {
    * @param expected Expected array.
    * @param message Custom assertion failure message.
    */
-  public arraysToBeEqual<T extends unknown[]>(actual: T, expected: T, message?: string) {
+  public arraysToBeEqual<T extends readonly unknown[]>(actual: T, expected: T, message?: string) {
     if (actual.length !== expected.length)
       throw new ExpectationError(message || `Expected sequences to be equal, but their lenghts were different.`);
 
@@ -219,7 +219,7 @@ class Expect {
    * @param array Array in which the given item is expected to be.
    * @param message Custom assertion failure message.
    */
-  public toBeIn<T>(item: T, array: T[], message?: string) {
+  public toBeIn<T>(item: T, array: readonly T[], message?: string) {
     const isIn = array.find((x) => x === item);
     if (this.notFlag ? isIn : !isIn) {
       throw new ExpectationError(

--- a/src/spec/assertion/arraysToBeEqual.spec.ts
+++ b/src/spec/assertion/arraysToBeEqual.spec.ts
@@ -10,6 +10,13 @@ export class ExpectArraysToBeEqualTestSuite {
   private equal(actual, expected) {
     expect.arraysToBeEqual(actual, expected);
   }
+  
+  @Test('ReadonlyArrays to be equal')
+  private equal() {
+    const actual: ReaonlyArray<string> = ['a', 'b', 'c'];
+    const expected: ReaonlyArray<string> = ['a', 'b', 'c'];
+    expect.arraysToBeEqual(actual, expected);
+  }  
 
   @Test('Arrays to be equal, should fail')
   @TestCase(`'a, b, c' to equal 'b, c, a'`, ['a', 'b', 'c'], ['b', 'c', 'a'])

--- a/src/spec/assertion/toBeIn.spec.ts
+++ b/src/spec/assertion/toBeIn.spec.ts
@@ -7,6 +7,12 @@ export class ExpectToMatch {
   private aToBeInSuccess() {
     expect.toBeIn('a', ['a', 'b', 'c']);
   }
+  
+  @Test(`'a' to be in ReadonlyArray, should succeed`)
+  private aToBeInReadonlySuccess() {
+    const readonlyArray: ReaonlyArray<string> = ['a', 'b', 'c'];
+    expect.toBeIn('a', readonlyArray);
+  }  
 
   @Test(`'a' to be in, should fail`)
   private aToBeInFail() {


### PR DESCRIPTION
The array arguments have no business being mutable.

## Purpose

The assertion functions can't be called with ReadonlyArray<T>. That is bad.

## Approach

Make the arguments `readonly`.

## Learnings

https://www.typescriptlang.org/docs/handbook/interfaces.html#readonly-properties
